### PR TITLE
feat!: export widgets

### DIFF
--- a/docs/api/widgets/Arrow.rst
+++ b/docs/api/widgets/Arrow.rst
@@ -1,5 +1,5 @@
 Arrow
 -----
 
-.. autoclass:: ignis.widgets.Widget.Arrow
+.. autoclass:: ignis.widgets.Arrow
     :members:

--- a/docs/api/widgets/ArrowButton.rst
+++ b/docs/api/widgets/ArrowButton.rst
@@ -1,5 +1,5 @@
 ArrowButton
 -----------
 
-.. autoclass:: ignis.widgets.Widget.ArrowButton
+.. autoclass:: ignis.widgets.ArrowButton
     :members:

--- a/docs/api/widgets/Box.rst
+++ b/docs/api/widgets/Box.rst
@@ -1,5 +1,5 @@
 Box
 ---
 
-.. autoclass:: ignis.widgets.Widget.Box
+.. autoclass:: ignis.widgets.Box
     :members:

--- a/docs/api/widgets/Button.rst
+++ b/docs/api/widgets/Button.rst
@@ -1,5 +1,5 @@
 Button
 ------
 
-.. autoclass:: ignis.widgets.Widget.Button
+.. autoclass:: ignis.widgets.Button
     :members:

--- a/docs/api/widgets/Calendar.rst
+++ b/docs/api/widgets/Calendar.rst
@@ -1,5 +1,5 @@
 Calendar
 --------
 
-.. autoclass:: ignis.widgets.Widget.Calendar
+.. autoclass:: ignis.widgets.Calendar
     :members:

--- a/docs/api/widgets/CenterBox.rst
+++ b/docs/api/widgets/CenterBox.rst
@@ -1,5 +1,5 @@
 CenterBox
 ---------
 
-.. autoclass:: ignis.widgets.Widget.CenterBox
+.. autoclass:: ignis.widgets.CenterBox
     :members:

--- a/docs/api/widgets/CheckButton.rst
+++ b/docs/api/widgets/CheckButton.rst
@@ -1,5 +1,5 @@
 CheckButton
 -----------
 
-.. autoclass:: ignis.widgets.Widget.CheckButton
+.. autoclass:: ignis.widgets.CheckButton
     :members:

--- a/docs/api/widgets/DropDown.rst
+++ b/docs/api/widgets/DropDown.rst
@@ -1,5 +1,5 @@
 DropDown
 --------
 
-.. autoclass:: ignis.widgets.Widget.DropDown
+.. autoclass:: ignis.widgets.DropDown
     :members:

--- a/docs/api/widgets/Entry.rst
+++ b/docs/api/widgets/Entry.rst
@@ -1,5 +1,5 @@
 Entry
 -----
 
-.. autoclass:: ignis.widgets.Widget.Entry
+.. autoclass:: ignis.widgets.Entry
     :members:

--- a/docs/api/widgets/EventBox.rst
+++ b/docs/api/widgets/EventBox.rst
@@ -1,5 +1,5 @@
 EventBox
 --------
 
-.. autoclass:: ignis.widgets.Widget.EventBox
+.. autoclass:: ignis.widgets.EventBox
     :members:

--- a/docs/api/widgets/FileChooserButton.rst
+++ b/docs/api/widgets/FileChooserButton.rst
@@ -1,5 +1,5 @@
 FileChooserButton
 -----------------
 
-.. autoclass:: ignis.widgets.Widget.FileChooserButton
+.. autoclass:: ignis.widgets.FileChooserButton
     :members:

--- a/docs/api/widgets/FileDialog.rst
+++ b/docs/api/widgets/FileDialog.rst
@@ -1,5 +1,5 @@
 FileDialog
 ----------
 
-.. autoclass:: ignis.widgets.Widget.FileDialog
+.. autoclass:: ignis.widgets.FileDialog
     :members:

--- a/docs/api/widgets/FileFilter.rst
+++ b/docs/api/widgets/FileFilter.rst
@@ -1,5 +1,5 @@
 FileFilter
 ----------
 
-.. autoclass:: ignis.widgets.Widget.FileFilter
+.. autoclass:: ignis.widgets.FileFilter
     :members:

--- a/docs/api/widgets/Grid.rst
+++ b/docs/api/widgets/Grid.rst
@@ -1,5 +1,5 @@
 Grid
 ----
 
-.. autoclass:: ignis.widgets.Widget.Grid
+.. autoclass:: ignis.widgets.Grid
     :members:

--- a/docs/api/widgets/HeaderBar.rst
+++ b/docs/api/widgets/HeaderBar.rst
@@ -1,5 +1,5 @@
 HeaderBar
 ---------
 
-.. autoclass:: ignis.widgets.Widget.HeaderBar
+.. autoclass:: ignis.widgets.HeaderBar
     :members:

--- a/docs/api/widgets/Icon.rst
+++ b/docs/api/widgets/Icon.rst
@@ -1,5 +1,5 @@
 Icon
 ----
 
-.. autoclass:: ignis.widgets.Widget.Icon
+.. autoclass:: ignis.widgets.Icon
     :members:

--- a/docs/api/widgets/Label.rst
+++ b/docs/api/widgets/Label.rst
@@ -1,5 +1,5 @@
 Label
 -----
 
-.. autoclass:: ignis.widgets.Widget.Label
+.. autoclass:: ignis.widgets.Label
     :members:

--- a/docs/api/widgets/ListBox.rst
+++ b/docs/api/widgets/ListBox.rst
@@ -1,5 +1,5 @@
 ListBox
 -------
 
-.. autoclass:: ignis.widgets.Widget.ListBox
+.. autoclass:: ignis.widgets.ListBox
     :members:

--- a/docs/api/widgets/ListBoxRow.rst
+++ b/docs/api/widgets/ListBoxRow.rst
@@ -1,5 +1,5 @@
 ListBoxRow
 ----------
 
-.. autoclass:: ignis.widgets.Widget.ListBoxRow
+.. autoclass:: ignis.widgets.ListBoxRow
     :members:

--- a/docs/api/widgets/Overlay.rst
+++ b/docs/api/widgets/Overlay.rst
@@ -1,5 +1,5 @@
 Overlay
 -------
 
-.. autoclass:: ignis.widgets.Widget.Overlay
+.. autoclass:: ignis.widgets.Overlay
     :members:

--- a/docs/api/widgets/Picture.rst
+++ b/docs/api/widgets/Picture.rst
@@ -1,5 +1,5 @@
 Picture
 -------
 
-.. autoclass:: ignis.widgets.Widget.Picture
+.. autoclass:: ignis.widgets.Picture
     :members:

--- a/docs/api/widgets/PopoverMenu.rst
+++ b/docs/api/widgets/PopoverMenu.rst
@@ -1,5 +1,5 @@
 PopoverMenu
 -----------
 
-.. autoclass:: ignis.widgets.Widget.PopoverMenu
+.. autoclass:: ignis.widgets.PopoverMenu
     :members:

--- a/docs/api/widgets/RegularWindow.rst
+++ b/docs/api/widgets/RegularWindow.rst
@@ -1,5 +1,5 @@
 RegularWindow
 -------------
 
-.. autoclass:: ignis.widgets.Widget.RegularWindow
+.. autoclass:: ignis.widgets.RegularWindow
     :members:

--- a/docs/api/widgets/Revealer.rst
+++ b/docs/api/widgets/Revealer.rst
@@ -1,5 +1,5 @@
 Revealer
 --------
 
-.. autoclass:: ignis.widgets.Widget.Revealer
+.. autoclass:: ignis.widgets.Revealer
     :members:

--- a/docs/api/widgets/RevealerWindow.rst
+++ b/docs/api/widgets/RevealerWindow.rst
@@ -1,5 +1,5 @@
 RevealerWindow
 --------------
 
-.. autoclass:: ignis.widgets.Widget.RevealerWindow
+.. autoclass:: ignis.widgets.RevealerWindow
     :members:

--- a/docs/api/widgets/Scale.rst
+++ b/docs/api/widgets/Scale.rst
@@ -1,5 +1,5 @@
 Scale
 -----
 
-.. autoclass:: ignis.widgets.Widget.Scale
+.. autoclass:: ignis.widgets.Scale
     :members:

--- a/docs/api/widgets/Scroll.rst
+++ b/docs/api/widgets/Scroll.rst
@@ -1,5 +1,5 @@
 Scroll
 ------
 
-.. autoclass:: ignis.widgets.Widget.Scroll
+.. autoclass:: ignis.widgets.Scroll
     :members:

--- a/docs/api/widgets/Separator.rst
+++ b/docs/api/widgets/Separator.rst
@@ -1,5 +1,5 @@
 Separator
 ---------
 
-.. autoclass:: ignis.widgets.Widget.Separator
+.. autoclass:: ignis.widgets.Separator
     :members:

--- a/docs/api/widgets/SpinButton.rst
+++ b/docs/api/widgets/SpinButton.rst
@@ -1,5 +1,5 @@
 SpinButton
 ----------
 
-.. autoclass:: ignis.widgets.Widget.SpinButton
+.. autoclass:: ignis.widgets.SpinButton
     :members:

--- a/docs/api/widgets/Stack.rst
+++ b/docs/api/widgets/Stack.rst
@@ -1,11 +1,11 @@
 Stack
 =======
 
-.. autoclass:: ignis.widgets.Widget.Stack
+.. autoclass:: ignis.widgets.Stack
     :members:
 
-.. autoclass:: ignis.widgets.Widget.StackPage
+.. autoclass:: ignis.widgets.StackPage
     :members:
 
-.. autoclass:: ignis.widgets.Widget.StackSwitcher
+.. autoclass:: ignis.widgets.StackSwitcher
     :members:

--- a/docs/api/widgets/Switch.rst
+++ b/docs/api/widgets/Switch.rst
@@ -1,5 +1,5 @@
 Switch
 ------
 
-.. autoclass:: ignis.widgets.Widget.Switch
+.. autoclass:: ignis.widgets.Switch
     :members:

--- a/docs/api/widgets/ToggleButton.rst
+++ b/docs/api/widgets/ToggleButton.rst
@@ -1,5 +1,5 @@
 ToggleButton
 ------------
 
-.. autoclass:: ignis.widgets.Widget.ToggleButton
+.. autoclass:: ignis.widgets.ToggleButton
     :members:

--- a/docs/api/widgets/Window.rst
+++ b/docs/api/widgets/Window.rst
@@ -1,5 +1,5 @@
 Window
 ------
 
-.. autoclass:: ignis.widgets.Widget.Window
+.. autoclass:: ignis.widgets.Window
     :members:

--- a/docs/api/widgets/index.rst
+++ b/docs/api/widgets/index.rst
@@ -1,13 +1,13 @@
 Widgets
 ==========
 
-To get widgets, use the universal ``Widget`` class.
+To access widgets, use the ``ignis.widgets`` package.
 
 .. code-block:: python
 
-   from ignis.widgets import Widget
+   from ignis import widgets
 
-   Widget.WIDGET_NAME()
+   widgets.WIDGET_NAME()
 
 Enums
 ----------------
@@ -29,9 +29,9 @@ This can be useful when you need to perform actions when the widget is initializ
 
 .. code-block:: python
 
-   from ignis.widgets import Widget
+   from ignis import widgets
 
-   Widget.Label(
+   widgets.Label(
       label="you will not see this text", 
       setup=lambda self: self.set_label("instead, you will see this")
    )

--- a/docs/dev/documentation.rst
+++ b/docs/dev/documentation.rst
@@ -134,7 +134,7 @@ Widgets
 
         .. code-block:: python
 
-            Widget.WIDGET_NAME(
+            widgets.WIDGET_NAME(
                 prop1="asd",
                 prop2=12
             )

--- a/docs/examples/code_snippets.rst
+++ b/docs/examples/code_snippets.rst
@@ -10,11 +10,11 @@ A common use case is to close a window.
 
 .. code-block:: python
 
-    Widget.Window(
+    widgets.Window(
         namespace="my-window",
         anchor=["left", "right", "top", "bottom"],  # to make a window fullscreen
-        child=Widget.Overlay(
-            child=Widget.Button(
+        child=widgets.Overlay(
+            child=widgets.Button(
                 vexpand=True,
                 hexpand=True,
                 can_focus=False,
@@ -67,16 +67,16 @@ Display applications icons on Hyprland workspaces buttons
 
     # The code from the example bar
 
-    def hyprland_workspace_button(workspace: HyprlandWorkspace) -> Widget.Button:
-        widget = Widget.Button(
+    def hyprland_workspace_button(workspace: HyprlandWorkspace) -> widgets.Button:
+        widget = widgets.Button(
             css_classes=["workspace"],
             on_click=lambda x: workspace.switch_to(),
-            child=Widget.Box(
+            child=widgets.Box(
                 child=hyprland.bind(
                     "windows",
                     lambda _: [
                         # find the icon of the app by its class name
-                        Widget.Icon(icon_name=Utils.get_app_icon_name(window.class_name))
+                        widgets.Icon(icon_name=Utils.get_app_icon_name(window.class_name))
                         # get all windows on the current workspace
                         for window in hyprland.get_windows_on_workspace(
                             workspace_id=workspace.id

--- a/docs/user/dynamic_content.rst
+++ b/docs/user/dynamic_content.rst
@@ -6,22 +6,22 @@ Static text can be boring, so let's add some dynamic elements!
 .. code-block:: python
 
     import datetime
-    from ignis.widgets import Widget
+    from ignis import widgets
     from ignis.utils import Utils
 
-    def update_label(clock_label: Widget.Label) -> None:
+    def update_label(clock_label: widgets.Label) -> None:
         text = datetime.datetime.now().strftime("%H:%M:%S")
         clock_label.set_label(text)
 
-    def bar(monitor: int) -> Widget.Window:
-        clock_label = Widget.Label()
+    def bar(monitor: int) -> widgets.Window:
+        clock_label = widgets.Label()
 
         Utils.Poll(1000, lambda x: update_label(clock_label))
 
-        return Widget.Window(
+        return widgets.Window(
             namespace=f"some-window-{monitor}",
             monitor=monitor,
-            child=Widget.Box(
+            child=widgets.Box(
                 vertical=True,
                 spacing=10,
                 child=[clock_label],
@@ -35,7 +35,7 @@ Signals
 
 Polling data every second isn't always ideal, as it can negatively impact performance.
 This is where **signals** are useful. 
-Signals let us call a callback only when an event occurs (like ``on_click`` in ``Widget.Button``).
+Signals let us call a callback only when an event occurs (like ``on_click`` in ``widgets.Button``).
 
 Let's consider services, which often have both **signals** and **properties**.
 
@@ -68,18 +68,18 @@ Use the ``.bind()`` method, passing the property name as the first argument, and
 .. code-block:: python
 
     from ignis.services.audio import AudioService
-    from ignis.widgets import Widget
+    from ignis import widgets
 
     audio = AudioService.get_default()
 
-    def bar(monitor: int) -> Widget.Window:
-        return Widget.Window(
+    def bar(monitor: int) -> widgets.Window:
+        return widgets.Window(
             namespace=f"some-window-{monitor}",
             monitor=monitor,
-            child=Widget.Box(
+            child=widgets.Box(
                 child=[
-                    Widget.Label(label="Current volume: "),
-                    Widget.Label(
+                    widgets.Label(label="Current volume: "),
+                    widgets.Label(
                         label=audio.speaker.bind("volume", lambda value: str(value))  # this function converts the value to a string
                     )
                 ]
@@ -97,7 +97,7 @@ You can bind multiple properties at the same time with ``bind_many()``.
 
 .. code-block:: python
 
-    Widget.Scale(
+    widgets.Scale(
         value=audio.speaker.bind_many(
             ["volume", "is_muted"],
             lambda volume, is_muted: 0 if is_muted else volume,

--- a/docs/user/first_widgets.rst
+++ b/docs/user/first_widgets.rst
@@ -14,11 +14,11 @@ The window is the top-level widget that holds all other widgets.
 
 .. code-block:: python
     
-    from ignis.widgets import Widget
+    from ignis import widgets
     
-    Widget.Window(
+    widgets.Window(
         namespace="some-window",  # the name of the window (not title!)
-        child=Widget.Label(  # we set Widget.Label as the child widget of the window
+        child=widgets.Label(  # we set widgets.Label as the child widget of the window
             label="Hello world!"  # define text here
         ),
     )
@@ -32,10 +32,10 @@ You should see a window that looks like this:
     :alt: "Hello world!" window
 
 This code imports the universal ``Widget`` class, which is used to access all widgets available in Ignis.
-To initialize a widget, simply call it: ``Widget.WIDGET_NAME()``.
+To initialize a widget, simply call it: ``widgets.WIDGET_NAME()``.
 Using keyword arguments (kwargs), you can set properties of the widget.
 
-A list of all properties is provided here: :class:`~ignis.widgets.Widget.Window`. 
+A list of all properties is provided here: :class:`~ignis.widgets.Window`. 
 Feel free to experiment with them.
 
 Boxes
@@ -47,20 +47,20 @@ Let's add some boxes to the window.
 
 .. code-block:: python
 
-    from ignis.widgets import Widget
+    from ignis import widgets
 
-    Widget.Window(
+    widgets.Window(
         namespace="some-window",
-        child=Widget.Box(
+        child=widgets.Box(
             vertical=True,  # this box is vertical
             spacing=10,  # add some spacing between widgets
             child=[  # define list of child widgets here
-                Widget.Label(label="This is the first child of the first box"),
-                Widget.Box(
+                widgets.Label(label="This is the first child of the first box"),
+                widgets.Box(
                     spacing=26,
                     child=[
-                        Widget.Label(label="This is the first child of the second box"),
-                        Widget.Label(label="Second child (by default this box child will be added horizontally)"),
+                        widgets.Label(label="This is the first child of the second box"),
+                        widgets.Label(label="Second child (by default this box child will be added horizontally)"),
                     ]
                 ),
             ],
@@ -79,7 +79,7 @@ Let's add a couple of buttons to our window that will perform actions when press
 
 .. code-block:: python
 
-    from ignis.widgets import Widget
+    from ignis import widgets
 
     def complex_operation(x):
         print("Doing something 1")
@@ -88,26 +88,26 @@ Let's add a couple of buttons to our window that will perform actions when press
 
 
     # you can assign widgets to variables
-    button1 = Widget.Button(
-        child=Widget.Label(label="Click me!"),
+    button1 = widgets.Button(
+        child=widgets.Label(label="Click me!"),
         on_click=lambda x: print("you clicked the button 1"),
     )
-    button2 = Widget.Button(
-        child=Widget.Label(label="Don't listen him! Click me!"), on_click=complex_operation
+    button2 = widgets.Button(
+        child=widgets.Label(label="Don't listen him! Click me!"), on_click=complex_operation
     )
-    button3 = Widget.Button(
-        child=Widget.Label(label="Click me and text will change"),
+    button3 = widgets.Button(
+        child=widgets.Label(label="Click me and text will change"),
         on_click=lambda x: x.child.set_label("Text changed!"),
     )
 
-    Widget.Window(
+    widgets.Window(
         namespace="some-window",
-        child=Widget.Box(
+        child=widgets.Box(
             vertical=True,
             spacing=10,
             child=[
-                Widget.Label(label="Click buttons)))"),
-                Widget.Box(
+                widgets.Label(label="Click buttons)))"),
+                widgets.Box(
                     spacing=26,
                     child=[
                         button1,
@@ -130,40 +130,40 @@ Reusable Widgets
 -------------------
 
 In previous examples, widgets are declared as single instances.
-One ``Widget.Label`` cannot be added to two boxes at the same time.
+One ``widgets.Label`` cannot be added to two boxes at the same time.
 But what if you have two monitors and want to display the bar on both?
 The solution is to create functions that return widget instances.
 
 .. code-block:: python
 
-    from ignis.widgets import Widget
+    from ignis import widgets
 
     def complex_operation(x):
         print("Doing something 1")
         print("Doing something 2")
         print("Doing something 3")
 
-    def bar(monitor: int) -> Widget.Window:  # type hinting is good practice!
-        button1 = Widget.Button(
-            child=Widget.Label(label="Click me!"),
+    def bar(monitor: int) -> widgets.Window:  # type hinting is good practice!
+        button1 = widgets.Button(
+            child=widgets.Label(label="Click me!"),
             on_click=lambda x: print("you clicked the button 1"),
         )
-        button2 = Widget.Button(
-            child=Widget.Label(label="Don't listen him! Click me!"), on_click=complex_operation
+        button2 = widgets.Button(
+            child=widgets.Label(label="Don't listen him! Click me!"), on_click=complex_operation
         )
-        button3 = Widget.Button(
-            child=Widget.Label(label="Click me and text will change"),
+        button3 = widgets.Button(
+            child=widgets.Label(label="Click me and text will change"),
             on_click=lambda x: x.child.set_label("Text changed!"),
         )
 
-        return Widget.Window(
+        return widgets.Window(
             namespace=f"some-window-{monitor}",  # the namespace must be unique
             monitor=monitor,
             anchor=["left", "top", "right"],  # btw put this window in the top
-            child=Widget.Box(
+            child=widgets.Box(
                 spacing=10,
                 child=[
-                    Widget.Label(label="Click buttons)))"),
+                    widgets.Label(label="Click buttons)))"),
                     button1,
                     button2,
                     button3,
@@ -185,14 +185,14 @@ GObject properties can be accessed or set using the standard Python approach.
 
 .. code-block:: python
 
-    widget = Widget.Label(label="Hello world!")
+    widget = widgets.Label(label="Hello world!")
     print(widget.label) # prints: "Hello world!"
 
 To set a property, you can use the assignment operator ``=`` or a method that starts with ``set_``.
 
 .. code-block:: python
 
-    widget = Widget.Label()
+    widget = widgets.Label()
     
     widget.label = "test"
     print(widget.label) # prints: "test"

--- a/docs/user/styling.rst
+++ b/docs/user/styling.rst
@@ -31,7 +31,7 @@ To add CSS classes to a widget, use the ``css_classes`` property.
 
 .. code-block:: python
     
-    Widget.Label(
+    widgets.Label(
         label="hello",
         css_classes=["my-label"]
     )
@@ -52,7 +52,7 @@ Using the ``style`` property
 
 .. code-block:: python
 
-    Widget.Label(
+    widgets.Label(
         label="hello",
         style="background-color: black;"
     )

--- a/docs/user/troubleshooting.rst
+++ b/docs/user/troubleshooting.rst
@@ -1,13 +1,13 @@
 Troubleshooting
 ================
 
-Cannot view children of ``Widget.Scroll`` 
+Cannot view children of ``widgets.Scroll`` 
 ------------------------------------------
 
-Set ``min-height: 100px;`` or ``min-width: 100px;`` to your ``Widget.Scroll`` in CSS.
+Set ``min-height: 100px;`` or ``min-width: 100px;`` to your ``widgets.Scroll`` in CSS.
 Where ``100px`` you can set any value.
 
-Alternatively, set ``vexpand=True`` or ``hexpand=True`` to your ``Widget.Scroll``.
+Alternatively, set ``vexpand=True`` or ``hexpand=True`` to your ``widgets.Scroll``.
 
 Render issues or Unresponsive UI after wake up from suspend
 -----------------------------------------------------------

--- a/docs/user/using_classes.rst
+++ b/docs/user/using_classes.rst
@@ -9,34 +9,34 @@ and the ability to use ``self``, which is especially useful for complex widgets.
 
 .. code-block:: python
 
-    from ignis.widgets import Widget
+    from ignis import widgets
 
 
-    class Bar(Widget.Window):  # inheriting from Widget.Window
+    class Bar(widgets.Window):  # inheriting from widgets.Window
         __gtype_name__ = "MyBar"  # optional, this will change the widget's display name in the GTK inspector.
 
         def __init__(self, monitor: int):
-            button1 = Widget.Button(
-                child=Widget.Label(label="Click me!"),
+            button1 = widgets.Button(
+                child=widgets.Label(label="Click me!"),
                 on_click=lambda x: print("you clicked the button 1"),
             )
-            button2 = Widget.Button(
-                child=Widget.Label(label="Close window"),
+            button2 = widgets.Button(
+                child=widgets.Label(label="Close window"),
                 on_click=lambda x: self.set_visible(False),  # you can use "self" - the window object itself
             )
-            button3 = Widget.Button(
-                child=Widget.Label(label="Custom function on self"),
+            button3 = widgets.Button(
+                child=widgets.Label(label="Custom function on self"),
                 on_click=lambda x: self.some_func(),
             )
 
-            super().__init__(  # calling the constructor of the parent class (Widget.Window)
+            super().__init__(  # calling the constructor of the parent class (widgets.Window)
                 namespace=f"some-window-{monitor}",
                 monitor=monitor,
                 anchor=["left", "top", "right"],
-                child=Widget.Box(
+                child=widgets.Box(
                     spacing=10,
                     child=[
-                        Widget.Label(label="This window created using a custom class!"),
+                        widgets.Label(label="This window created using a custom class!"),
                         button1,
                         button2,
                         button3,

--- a/examples/bar/config.py
+++ b/examples/bar/config.py
@@ -1,7 +1,7 @@
 import datetime
 import asyncio
 from ignis.menu_model import IgnisMenuModel, IgnisMenuItem, IgnisMenuSeparator
-from ignis.widgets import Widget
+from ignis import widgets
 from ignis.utils import Utils
 from ignis.app import IgnisApp
 from ignis.services.audio import AudioService
@@ -24,11 +24,11 @@ notifications = NotificationService.get_default()
 mpris = MprisService.get_default()
 
 
-def hyprland_workspace_button(workspace: HyprlandWorkspace) -> Widget.Button:
-    widget = Widget.Button(
+def hyprland_workspace_button(workspace: HyprlandWorkspace) -> widgets.Button:
+    widget = widgets.Button(
         css_classes=["workspace"],
         on_click=lambda x: workspace.switch_to(),
-        child=Widget.Label(label=str(workspace.id)),
+        child=widgets.Label(label=str(workspace.id)),
     )
     if workspace.id == hyprland.active_workspace.id:
         widget.add_css_class("active")
@@ -36,11 +36,11 @@ def hyprland_workspace_button(workspace: HyprlandWorkspace) -> Widget.Button:
     return widget
 
 
-def niri_workspace_button(workspace: NiriWorkspace) -> Widget.Button:
-    widget = Widget.Button(
+def niri_workspace_button(workspace: NiriWorkspace) -> widgets.Button:
+    widget = widgets.Button(
         css_classes=["workspace"],
         on_click=lambda x: workspace.switch_to(),
-        child=Widget.Label(label=str(workspace.idx)),
+        child=widgets.Label(label=str(workspace.idx)),
     )
     if workspace.is_active:
         widget.add_css_class("active")
@@ -48,13 +48,13 @@ def niri_workspace_button(workspace: NiriWorkspace) -> Widget.Button:
     return widget
 
 
-def workspace_button(workspace) -> Widget.Button:
+def workspace_button(workspace) -> widgets.Button:
     if hyprland.is_available:
         return hyprland_workspace_button(workspace)
     elif niri.is_available:
         return niri_workspace_button(workspace)
     else:
-        return Widget.Button()
+        return widgets.Button()
 
 
 def hyprland_scroll_workspaces(direction: str) -> None:
@@ -90,8 +90,8 @@ def scroll_workspaces(direction: str, monitor_name: str = "") -> None:
         pass
 
 
-def hyprland_workspaces() -> Widget.EventBox:
-    return Widget.EventBox(
+def hyprland_workspaces() -> widgets.EventBox:
+    return widgets.EventBox(
         on_scroll_up=lambda x: scroll_workspaces("up"),
         on_scroll_down=lambda x: scroll_workspaces("down"),
         css_classes=["workspaces"],
@@ -105,8 +105,8 @@ def hyprland_workspaces() -> Widget.EventBox:
     )
 
 
-def niri_workspaces(monitor_name: str) -> Widget.EventBox:
-    return Widget.EventBox(
+def niri_workspaces(monitor_name: str) -> widgets.EventBox:
+    return widgets.EventBox(
         on_scroll_up=lambda x: scroll_workspaces("up", monitor_name),
         on_scroll_down=lambda x: scroll_workspaces("down", monitor_name),
         css_classes=["workspaces"],
@@ -120,25 +120,25 @@ def niri_workspaces(monitor_name: str) -> Widget.EventBox:
     )
 
 
-def workspaces(monitor_name: str) -> Widget.EventBox:
+def workspaces(monitor_name: str) -> widgets.EventBox:
     if hyprland.is_available:
         return hyprland_workspaces()
     elif niri.is_available:
         return niri_workspaces(monitor_name)
     else:
-        return Widget.EventBox()
+        return widgets.EventBox()
 
 
-def mpris_title(player: MprisPlayer) -> Widget.Box:
-    return Widget.Box(
+def mpris_title(player: MprisPlayer) -> widgets.Box:
+    return widgets.Box(
         spacing=10,
         setup=lambda self: player.connect(
             "closed",
             lambda x: self.unparent(),  # remove widget when player is closed
         ),
         child=[
-            Widget.Icon(image="audio-x-generic-symbolic"),
-            Widget.Label(
+            widgets.Icon(image="audio-x-generic-symbolic"),
+            widgets.Label(
                 ellipsize="end",
                 max_width_chars=20,
                 label=player.bind("title"),
@@ -147,11 +147,11 @@ def mpris_title(player: MprisPlayer) -> Widget.Box:
     )
 
 
-def media() -> Widget.Box:
-    return Widget.Box(
+def media() -> widgets.Box:
+    return widgets.Box(
         spacing=10,
         child=[
-            Widget.Label(
+            widgets.Label(
                 label="No media players",
                 visible=mpris.bind("players", lambda value: len(value) == 0),
             )
@@ -162,16 +162,16 @@ def media() -> Widget.Box:
     )
 
 
-def hyprland_client_title() -> Widget.Label:
-    return Widget.Label(
+def hyprland_client_title() -> widgets.Label:
+    return widgets.Label(
         ellipsize="end",
         max_width_chars=40,
         label=hyprland.active_window.bind("title"),
     )
 
 
-def niri_client_title(monitor_name) -> Widget.Label:
-    return Widget.Label(
+def niri_client_title(monitor_name) -> widgets.Label:
+    return widgets.Label(
         ellipsize="end",
         max_width_chars=40,
         visible=niri.bind("active_output", lambda output: output == monitor_name),
@@ -179,17 +179,17 @@ def niri_client_title(monitor_name) -> Widget.Label:
     )
 
 
-def client_title(monitor_name: str) -> Widget.Label:
+def client_title(monitor_name: str) -> widgets.Label:
     if hyprland.is_available:
         return hyprland_client_title()
     elif niri.is_available:
         return niri_client_title(monitor_name)
     else:
-        return Widget.Label()
+        return widgets.Label()
 
 
-def current_notification() -> Widget.Label:
-    return Widget.Label(
+def current_notification() -> widgets.Label:
+    return widgets.Label(
         ellipsize="end",
         max_width_chars=20,
         label=notifications.bind(
@@ -198,9 +198,9 @@ def current_notification() -> Widget.Label:
     )
 
 
-def clock() -> Widget.Label:
+def clock() -> widgets.Label:
     # poll for current time every second
-    return Widget.Label(
+    return widgets.Label(
         css_classes=["clock"],
         label=Utils.Poll(
             1_000, lambda self: datetime.datetime.now().strftime("%H:%M")
@@ -208,52 +208,52 @@ def clock() -> Widget.Label:
     )
 
 
-def speaker_volume() -> Widget.Box:
-    return Widget.Box(
+def speaker_volume() -> widgets.Box:
+    return widgets.Box(
         child=[
-            Widget.Icon(
+            widgets.Icon(
                 image=audio.speaker.bind("icon_name"), style="margin-right: 5px;"
             ),
-            Widget.Label(
+            widgets.Label(
                 label=audio.speaker.bind("volume", transform=lambda value: str(value))
             ),
         ]
     )
 
 
-def hyprland_keyboard_layout() -> Widget.EventBox:
-    return Widget.EventBox(
+def hyprland_keyboard_layout() -> widgets.EventBox:
+    return widgets.EventBox(
         on_click=lambda self: hyprland.main_keyboard.switch_layout("next"),
-        child=[Widget.Label(label=hyprland.main_keyboard.bind("active_keymap"))],
+        child=[widgets.Label(label=hyprland.main_keyboard.bind("active_keymap"))],
     )
 
 
-def niri_keyboard_layout() -> Widget.EventBox:
-    return Widget.EventBox(
+def niri_keyboard_layout() -> widgets.EventBox:
+    return widgets.EventBox(
         on_click=lambda self: niri.switch_kb_layout(),
-        child=[Widget.Label(label=niri.keyboard_layouts.bind("current_name"))],
+        child=[widgets.Label(label=niri.keyboard_layouts.bind("current_name"))],
     )
 
 
-def keyboard_layout() -> Widget.EventBox:
+def keyboard_layout() -> widgets.EventBox:
     if hyprland.is_available:
         return hyprland_keyboard_layout()
     elif niri.is_available:
         return niri_keyboard_layout()
     else:
-        return Widget.EventBox()
+        return widgets.EventBox()
 
 
-def tray_item(item: SystemTrayItem) -> Widget.Button:
+def tray_item(item: SystemTrayItem) -> widgets.Button:
     if item.menu:
         menu = item.menu.copy()
     else:
         menu = None
 
-    return Widget.Button(
-        child=Widget.Box(
+    return widgets.Button(
+        child=widgets.Box(
             child=[
-                Widget.Icon(image=item.bind("icon"), pixel_size=24),
+                widgets.Icon(image=item.bind("icon"), pixel_size=24),
                 menu,
             ]
         ),
@@ -266,7 +266,7 @@ def tray_item(item: SystemTrayItem) -> Widget.Button:
 
 
 def tray():
-    return Widget.Box(
+    return widgets.Box(
         setup=lambda self: system_tray.connect(
             "added", lambda x, item: self.append(tray_item(item))
         ),
@@ -274,8 +274,8 @@ def tray():
     )
 
 
-def speaker_slider() -> Widget.Scale:
-    return Widget.Scale(
+def speaker_slider() -> widgets.Scale:
+    return widgets.Scale(
         min=0,
         max=100,
         step=1,
@@ -299,8 +299,8 @@ def logout() -> None:
         pass
 
 
-def power_menu() -> Widget.Button:
-    menu = Widget.PopoverMenu(
+def power_menu() -> widgets.Button:
+    menu = widgets.PopoverMenu(
         model=IgnisMenuModel(
             IgnisMenuItem(
                 label="Lock",
@@ -332,33 +332,33 @@ def power_menu() -> Widget.Button:
             ),
         ),
     )
-    return Widget.Button(
-        child=Widget.Box(
-            child=[Widget.Icon(image="system-shutdown-symbolic", pixel_size=20), menu]
+    return widgets.Button(
+        child=widgets.Box(
+            child=[widgets.Icon(image="system-shutdown-symbolic", pixel_size=20), menu]
         ),
         on_click=lambda x: menu.popup(),
     )
 
 
-def left(monitor_name: str) -> Widget.Box:
-    return Widget.Box(
+def left(monitor_name: str) -> widgets.Box:
+    return widgets.Box(
         child=[workspaces(monitor_name), client_title(monitor_name)], spacing=10
     )
 
 
-def center() -> Widget.Box:
-    return Widget.Box(
+def center() -> widgets.Box:
+    return widgets.Box(
         child=[
             current_notification(),
-            Widget.Separator(vertical=True, css_classes=["middle-separator"]),
+            widgets.Separator(vertical=True, css_classes=["middle-separator"]),
             media(),
         ],
         spacing=10,
     )
 
 
-def right() -> Widget.Box:
-    return Widget.Box(
+def right() -> widgets.Box:
+    return widgets.Box(
         child=[
             tray(),
             keyboard_layout(),
@@ -371,14 +371,14 @@ def right() -> Widget.Box:
     )
 
 
-def bar(monitor_id: int = 0) -> Widget.Window:
+def bar(monitor_id: int = 0) -> widgets.Window:
     monitor_name = Utils.get_monitor(monitor_id).get_connector()  # type: ignore
-    return Widget.Window(
+    return widgets.Window(
         namespace=f"ignis_bar_{monitor_id}",
         monitor=monitor_id,
         anchor=["left", "top", "right"],
         exclusivity="exclusive",
-        child=Widget.CenterBox(
+        child=widgets.CenterBox(
             css_classes=["bar"],
             start_widget=left(monitor_name),  # type: ignore
             center_widget=center(),

--- a/ignis/services/network/wifi_connect_dialog.py
+++ b/ignis/services/network/wifi_connect_dialog.py
@@ -1,16 +1,16 @@
 import asyncio
-from ignis.widgets import Widget
+from ignis import widgets
 from .util import get_wifi_connect_window_name
 from collections.abc import Callable
 
 
-class WifiConnectDialog(Widget.RegularWindow):
+class WifiConnectDialog(widgets.RegularWindow):
     """
     :meta private:
     """
 
     def __init__(self, access_point, callback: Callable | None = None) -> None:
-        self._password_entry = Widget.Entry(
+        self._password_entry = widgets.Entry(
             visibility=False,
             hexpand=True,
             on_accept=lambda x: asyncio.create_task(self.__connect_to()),
@@ -23,25 +23,25 @@ class WifiConnectDialog(Widget.RegularWindow):
             height_request=200,
             namespace=get_wifi_connect_window_name(access_point.bssid),
             style="padding: 1rem;",
-            child=Widget.Box(
+            child=widgets.Box(
                 vertical=True,
                 child=[
-                    Widget.Box(
+                    widgets.Box(
                         child=[
-                            Widget.Icon(
+                            widgets.Icon(
                                 icon_name="dialog-password",
                                 pixel_size=48,
                                 style="margin-bottom: 2rem; margin-right: 2rem; margin-left: 1rem; margin-top: 1rem;",
                             ),
-                            Widget.Box(
+                            widgets.Box(
                                 vertical=True,
                                 spacing=20,
                                 child=[
-                                    Widget.Label(
+                                    widgets.Label(
                                         label="Authentication required by Wi-Fi network",
                                         style="font-size: 1.1rem;",
                                     ),
-                                    Widget.Label(
+                                    widgets.Label(
                                         label=f'Passwords or encryption keys are required to access the Wi-Fi network "{access_point.ssid}".',
                                         wrap=True,
                                         max_width_chars=30,
@@ -51,29 +51,29 @@ class WifiConnectDialog(Widget.RegularWindow):
                             ),
                         ]
                     ),
-                    Widget.Box(
-                        child=[Widget.Label(label="Password"), self._password_entry],
+                    widgets.Box(
+                        child=[widgets.Label(label="Password"), self._password_entry],
                         spacing=10,
                         style="margin-top: 1rem;",
                     ),
-                    Widget.CheckButton(
+                    widgets.CheckButton(
                         label="Show password",
                         active=True,
                         on_toggled=lambda x,
                         active: self._password_entry.set_visibility(not active),
                         style="margin-left: 5.5rem; margin-top: 0.5rem;",
                     ),
-                    Widget.Box(
+                    widgets.Box(
                         vexpand=True,
                         valign="end",
                         halign="end",
                         spacing=10,
                         child=[
-                            Widget.Button(
+                            widgets.Button(
                                 label="Cancel",
                                 on_click=lambda x: self.unrealize(),
                             ),
-                            Widget.Button(
+                            widgets.Button(
                                 sensitive=self._password_entry.bind(
                                     "text", lambda value: len(value) >= 8
                                 ),

--- a/ignis/widgets/__init__.py
+++ b/ignis/widgets/__init__.py
@@ -34,8 +34,10 @@ from .revealer_window import RevealerWindow
 from .stack import Stack
 from .stack_switcher import StackSwitcher
 from .stack_page import StackPage
+from ignis.deprecation import deprecated_class
 
 
+@deprecated_class(message="{name}")
 class Widget:
     Window: TypeAlias = Window
     Label: TypeAlias = Label
@@ -72,3 +74,42 @@ class Widget:
     Stack: TypeAlias = Stack
     StackSwitcher: TypeAlias = StackSwitcher
     StackPage = StackPage
+
+
+__all__ = [
+    "Arrow",
+    "ArrowButton",
+    "Box",
+    "Button",
+    "Calendar",
+    "CenterBox",
+    "CheckButton",
+    "DropDown",
+    "Entry",
+    "EventBox",
+    "FileChooserButton",
+    "FileDialog",
+    "FileFilter",
+    "Grid",
+    "HeaderBar",
+    "Icon",
+    "Label",
+    "ListBox",
+    "ListBoxRow",
+    "Overlay",
+    "Picture",
+    "PopoverMenu",
+    "RegularWindow",
+    "Revealer",
+    "RevealerWindow",
+    "Scale",
+    "Scroll",
+    "Separator",
+    "SpinButton",
+    "Stack",
+    "StackPage",
+    "StackSwitcher",
+    "Switch",
+    "ToggleButton",
+    "Window",
+]

--- a/ignis/widgets/arrow.py
+++ b/ignis/widgets/arrow.py
@@ -22,15 +22,15 @@ class Arrow(Icon):
 
     .. hint::
         If you are looking for a button with an arrow that rotates on click,
-        see :class:`~ignis.widgets.Widget.ArrowButton`.
+        see :class:`~ignis.widgets.ArrowButton`.
 
     .. hint::
         You can set your custom icon name or image using the ``image`` property.
 
     .. code-block:: python
 
-        Widget.Arrow(
-            pixel_size=20, # inherited from Widget.Icon
+        widgets.Arrow(
+            pixel_size=20, # inherited from widgets.Icon
             rotated=False,
             degree=90,
             time=135,

--- a/ignis/widgets/arrow_button.py
+++ b/ignis/widgets/arrow_button.py
@@ -15,8 +15,8 @@ class ArrowButton(Button):
 
     .. code-block:: python
 
-        Widget.ArrowButton(
-            arrow=Widget.Arrow(
+        widgets.ArrowButton(
+            arrow=widgets.Arrow(
                 ... # Arrow-specific properties go here
             )
         )
@@ -39,6 +39,6 @@ class ArrowButton(Button):
 
     def toggle(self) -> None:
         """
-        Same as :func:`~ignis.widgets.Widget.Arrow.toggle`
+        Same as :func:`~ignis.widgets.Arrow.toggle`
         """
         self._arrow.toggle()

--- a/ignis/widgets/box.py
+++ b/ignis/widgets/box.py
@@ -17,14 +17,14 @@ class Box(Gtk.Box, BaseWidget):
 
         .. code-block::
 
-            Widget.Box(
-                child=[Widget.Label(label=str(i)) for i in range(10)]
+            widgets.Box(
+                child=[widgets.Label(label=str(i)) for i in range(10)]
             )
 
     .. code-block:: python
 
-        Widget.Box(
-            child=[Widget.Label(label='heh'), Widget.Label(label='heh2')],
+        widgets.Box(
+            child=[widgets.Label(label='heh'), widgets.Label(label='heh2')],
             vertical=False,
             homogeneous=False,
             spacing=52

--- a/ignis/widgets/button.py
+++ b/ignis/widgets/button.py
@@ -15,8 +15,8 @@ class Button(Gtk.Button, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Button(
-            child=Widget.Label(label="button"),
+        widgets.Button(
+            child=widgets.Label(label="button"),
             on_click=lambda self: print(self),
             on_right_click=lambda self: print(self),
             on_middle_click=lambda self: print(self),

--- a/ignis/widgets/calendar.py
+++ b/ignis/widgets/calendar.py
@@ -13,7 +13,7 @@ class Calendar(Gtk.Calendar, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Calendar(
+        widgets.Calendar(
             day=1,
             month=1,
             year=2024,

--- a/ignis/widgets/centerbox.py
+++ b/ignis/widgets/centerbox.py
@@ -14,11 +14,11 @@ class CenterBox(Gtk.CenterBox, BaseWidget):
 
     .. code-block:: python
 
-        Widget.CenterBox(
+        widgets.CenterBox(
             vertical=False,
-            start_widget=Widget.Label(label='start'),
-            center_widget=Widget.Label(label='center'),
-            end_widget=Widget.Label(label='end'),
+            start_widget=widgets.Label(label='start'),
+            center_widget=widgets.Label(label='center'),
+            end_widget=widgets.Label(label='end'),
         )
     """
 

--- a/ignis/widgets/check_button.py
+++ b/ignis/widgets/check_button.py
@@ -17,7 +17,7 @@ class CheckButton(Gtk.CheckButton, BaseWidget):
 
     .. code-block:: python
 
-        Widget.CheckButton(
+        widgets.CheckButton(
             label='check button',
             active=True,
         )
@@ -26,8 +26,8 @@ class CheckButton(Gtk.CheckButton, BaseWidget):
 
     .. code-block:: python
 
-        Widget.CheckButton(
-            group=Widget.CheckButton(label='radiobutton 1'),
+        widgets.CheckButton(
+            group=widgets.CheckButton(label='radiobutton 1'),
             label='radiobutton 2',
             active=True,
         )

--- a/ignis/widgets/dropdown.py
+++ b/ignis/widgets/dropdown.py
@@ -15,7 +15,7 @@ class DropDown(Gtk.DropDown, BaseWidget):
 
     .. code-block:: python
 
-        Widget.DropDown(
+        widgets.DropDown(
             items=["option 1", "option 2", "option 3"],
             on_selected=lambda x, selected: print(selected)
         )

--- a/ignis/widgets/entry.py
+++ b/ignis/widgets/entry.py
@@ -15,7 +15,7 @@ class Entry(Gtk.Entry, BaseWidget):  # type: ignore
 
     .. code-block:: python
 
-        Widget.Entry(
+        widgets.Entry(
             placeholder="placeholder",
             on_accept=lambda x: print(x.text),
             on_change=lambda x: print(x.text),

--- a/ignis/widgets/eventbox.py
+++ b/ignis/widgets/eventbox.py
@@ -16,8 +16,8 @@ class EventBox(Box):
 
     .. code-block:: python
 
-        Widget.EventBox(
-            child=[Widget.Label(label='this is eventbox'), Widget.Label(label="It can contain multiple child as Widget.Box")],
+        widgets.EventBox(
+            child=[widgets.Label(label='this is eventbox'), widgets.Label(label="It can contain multiple child as widgets.Box")],
             vertical=True,
             homogeneous=False,
             spacing=52,

--- a/ignis/widgets/file_chooser_button.py
+++ b/ignis/widgets/file_chooser_button.py
@@ -17,24 +17,24 @@ class FileChooserButton(Gtk.Button, BaseWidget):
     A button that allows the user to select a file.
 
     Args:
-        dialog: An instance of :class:`~ignis.widgets.Widget.FileDialog`.
-        label: An instance of :class:`~ignis.widgets.Widget.Label`.
+        dialog: An instance of :class:`~ignis.widgets.FileDialog`.
+        label: An instance of :class:`~ignis.widgets.Label`.
         **kwargs: Properties to set.
 
     .. code-block :: python
 
-        Widget.FileChooserButton(
-            dialog=Widget.FileDialog(
+        widgets.FileChooserButton(
+            dialog=widgets.FileDialog(
                 initial_path=os.path.expanduser("~/.wallpaper"),
                 filters=[
-                    Widget.FileFilter(
+                    widgets.FileFilter(
                         mime_types=["image/jpeg", "image/png"],
                         default=True,
                         name="Images JPEG/PNG",
                     )
                 ]
             ),
-            label=Widget.Label(label='Select', ellipsize="end", max_width_chars=20)
+            label=widgets.Label(label='Select', ellipsize="end", max_width_chars=20)
         )
     """
 
@@ -75,14 +75,14 @@ class FileChooserButton(Gtk.Button, BaseWidget):
     @IgnisProperty
     def dialog(self) -> FileDialog:
         """
-        An instance of :class:`~ignis.widgets.Widget.FileDialog`.
+        An instance of :class:`~ignis.widgets.FileDialog`.
         """
         return self._dialog
 
     @IgnisProperty
     def label(self) -> Label:
         """
-        An instance of :class:`~ignis.widgets.Widget.Label`.
+        An instance of :class:`~ignis.widgets.Label`.
         """
         return self._label
 

--- a/ignis/widgets/file_dialog.py
+++ b/ignis/widgets/file_dialog.py
@@ -21,12 +21,12 @@ class FileDialog(Gtk.FileDialog, IgnisGObject):
 
     .. code-block :: python
 
-        Widget.FileDialog(
+        widgets.FileDialog(
             initial_path=os.path.expanduser("~/.config"),
             on_file_set=lambda self, file: print(file.get_path()),
             select_folder=False,
             filters=[
-                Widget.FileFilter(
+                widgets.FileFilter(
                     mime_types=["image/jpeg", "image/png"],
                     default=True,
                     name="Images JPEG/PNG",

--- a/ignis/widgets/file_filter.py
+++ b/ignis/widgets/file_filter.py
@@ -12,7 +12,7 @@ class FileFilter(Gtk.FileFilter, IgnisGObject):
         It doesn't support common widget properties and cannot be added as a child to a container.
 
     A file filter.
-    Intended for use in :class:`~ignis.widgets.Widget.FileDialog`.
+    Intended for use in :class:`~ignis.widgets.FileDialog`.
     Uses MIME types, `here <https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types>`_ is a list of common MIME types.
 
     Args:
@@ -21,7 +21,7 @@ class FileFilter(Gtk.FileFilter, IgnisGObject):
 
     .. code-block :: python
 
-        Widget.FileFilter(
+        widgets.FileFilter(
             mime_types=["image/jpeg", "image/png"],
             default=True,
             name="Images JPEG/PNG",

--- a/ignis/widgets/grid.py
+++ b/ignis/widgets/grid.py
@@ -14,15 +14,15 @@ class Grid(Gtk.Grid, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Grid(
-            child=[Widget.Button(label=str(i)), for i in range(100)],
+        widgets.Grid(
+            child=[widgets.Button(label=str(i)), for i in range(100)],
             column_num=3
         )
 
     .. code-block:: python
 
-        Widget.Grid(
-            child=[Widget.Button(label=str(i)), for i in range(100)],
+        widgets.Grid(
+            child=[widgets.Button(label=str(i)), for i in range(100)],
             row_num=3
         )
     """

--- a/ignis/widgets/headerbar.py
+++ b/ignis/widgets/headerbar.py
@@ -13,7 +13,7 @@ class HeaderBar(Gtk.HeaderBar, BaseWidget):
 
     .. code-block:: python
 
-        Widget.HeaderBar(
+        widgets.HeaderBar(
             show_title_buttons=True,
         )
     """

--- a/ignis/widgets/icon.py
+++ b/ignis/widgets/icon.py
@@ -18,7 +18,7 @@ class Icon(Gtk.Image, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Icon(
+        widgets.Icon(
             image='audio-volume-high',
             pixel_size=12
         )

--- a/ignis/widgets/label.py
+++ b/ignis/widgets/label.py
@@ -35,7 +35,7 @@ class Label(Gtk.Label, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Label(
+        widgets.Label(
             label='heh',
             use_markup=False,
             justify='left',

--- a/ignis/widgets/listbox.py
+++ b/ignis/widgets/listbox.py
@@ -15,14 +15,14 @@ class ListBox(Gtk.ListBox, BaseWidget):
 
     .. code-block:: python
 
-        Widget.ListBox(
+        widgets.ListBox(
             rows=[
-                Widget.ListBoxRow(
-                    child=Widget.Label(label="row 1"),
+                widgets.ListBoxRow(
+                    child=widgets.Label(label="row 1"),
                     on_activate=lambda x: print("selected row 1"),
                 ),
-                Widget.ListBoxRow(
-                    child=Widget.Label(label="row 2"),
+                widgets.ListBoxRow(
+                    child=widgets.Label(label="row 2"),
                     on_activate=lambda x: print("selected row 2"),
                 ),
             ]

--- a/ignis/widgets/listboxrow.py
+++ b/ignis/widgets/listboxrow.py
@@ -15,8 +15,8 @@ class ListBoxRow(Gtk.ListBoxRow, BaseWidget):
 
     .. code-block:: python
 
-        Widget.ListBoxRow(
-            child=Widget.Label(label="row 1"),
+        widgets.ListBoxRow(
+            child=widgets.Label(label="row 1"),
             on_activate=lambda x: print("selected row 1"),
             selected=True
         )

--- a/ignis/widgets/overlay.py
+++ b/ignis/widgets/overlay.py
@@ -15,12 +15,12 @@ class Overlay(Gtk.Overlay, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Overlay(
-            child=Widget.Label(label="This is the main child"),
+        widgets.Overlay(
+            child=widgets.Label(label="This is the main child"),
             overlays=[
-                Widget.Label(label="Overlay child 1"),
-                Widget.Label(label="Overlay child 2"),
-                Widget.Label(label="Overlay child 3"),
+                widgets.Label(label="Overlay child 1"),
+                widgets.Label(label="Overlay child 2"),
+                widgets.Label(label="Overlay child 3"),
             ]
         )
     """

--- a/ignis/widgets/picture.py
+++ b/ignis/widgets/picture.py
@@ -27,7 +27,7 @@ class Picture(Gtk.Picture, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Picture(
+        widgets.Picture(
             image='path/to/img',
             width=20,
             height=30

--- a/ignis/widgets/popover_menu.py
+++ b/ignis/widgets/popover_menu.py
@@ -22,7 +22,7 @@ class PopoverMenu(Gtk.PopoverMenu, BaseWidget):
 
         from ignis.menu_model import IgnisMenuModel, IgnisMenuItem, IgnisMenuSeparator
 
-        Widget.PopoverMenu(
+        widgets.PopoverMenu(
             model=IgnisMenuModel(
                 IgnisMenuItem(
                     label="Just item",

--- a/ignis/widgets/regular_window.py
+++ b/ignis/widgets/regular_window.py
@@ -19,11 +19,11 @@ class RegularWindow(Gtk.Window, BaseWidget):
 
     .. code-block:: python
 
-        Widget.RegularWindow(
-            child=Widget.Label(label="this is regular window"),
+        widgets.RegularWindow(
+            child=widgets.Label(label="this is regular window"),
             title="This is title",
             namespace='some-regular-window',
-            titlebar=Widget.HeaderBar(show_title_buttons=True),
+            titlebar=widgets.HeaderBar(show_title_buttons=True),
         )
     """
 

--- a/ignis/widgets/revealer.py
+++ b/ignis/widgets/revealer.py
@@ -28,8 +28,8 @@ class Revealer(Gtk.Revealer, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Revealer(
-            child=Widget.Label(label='animation!!!'),
+        widgets.Revealer(
+            child=widgets.Label(label='animation!!!'),
             transition_type='slideright',
             transition_duration=500,
             reveal_child=True, # Whether child is revealed.

--- a/ignis/widgets/revealer_window.py
+++ b/ignis/widgets/revealer_window.py
@@ -7,40 +7,40 @@ from ignis.gobject import IgnisProperty
 
 class RevealerWindow(Window):
     """
-    Bases: :class:`~ignis.widgets.Widget.Window`
+    Bases: :class:`~ignis.widgets.Window`
 
     A window with animation.
 
     Args:
-        revealer: An instance of :class:`~ignis.widgets.Widget.Revealer`.
+        revealer: An instance of :class:`~ignis.widgets.Revealer`.
         **kwargs: Properties to set.
 
     .. warning::
-        Do not set ``Widget.Revealer`` as a direct child,
+        Do not set ``widgets.Revealer`` as a direct child,
         as this can lead to various graphical bugs.
-        Instead, place `Widget.Revealer` inside a container (e.g., `Widget.Box`) and then set the container as a child.
+        Instead, place `widgets.Revealer` inside a container (e.g., `widgets.Box`) and then set the container as a child.
 
     Example usage:
 
     .. code-block:: python
 
-        from ignis.widgets import Widget
+        from ignis import widgets
 
-        revealer = Widget.Revealer(
+        revealer = widgets.Revealer(
             transition_type="slide_left",
-            child=Widget.Button(label="test"),
+            child=widgets.Button(label="test"),
             transition_duration=300,
             reveal_child=True,
         )
 
-        box = Widget.Box(child=[revealer])
+        box = widgets.Box(child=[revealer])
 
-        Widget.RevealerWindow(
+        widgets.RevealerWindow(
             visible=False,
             popup=True,
             layer="top",
             namespace="revealer-window",
-            child=box,  # do not set Widget.Revealer as a direct child!
+            child=box,  # do not set widgets.Revealer as a direct child!
             revealer=revealer,
         )
 
@@ -75,7 +75,7 @@ class RevealerWindow(Window):
     @IgnisProperty
     def revealer(self) -> Revealer:
         """
-        An instance of :class:`~ignis.widgets.Widget.Revealer`.
+        An instance of :class:`~ignis.widgets.Revealer`.
         """
         return self._revealer
 

--- a/ignis/widgets/scale.py
+++ b/ignis/widgets/scale.py
@@ -24,7 +24,7 @@ class Scale(Gtk.Scale, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Scale(
+        widgets.Scale(
             vertical=False,
             min=0,
             max=100,

--- a/ignis/widgets/scroll.py
+++ b/ignis/widgets/scroll.py
@@ -13,10 +13,10 @@ class Scroll(Gtk.ScrolledWindow, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Scroll(
-            child=Widget.Box(
+        widgets.Scroll(
+            child=widgets.Box(
                 vertical=True,
-                child=[Widget.Label(i) for i in range(30)]
+                child=[widgets.Label(i) for i in range(30)]
             )
         )
     """

--- a/ignis/widgets/separator.py
+++ b/ignis/widgets/separator.py
@@ -14,7 +14,7 @@ class Separator(Gtk.Separator, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Separator(
+        widgets.Separator(
             vertical=False,
         )
     """

--- a/ignis/widgets/spin_button.py
+++ b/ignis/widgets/spin_button.py
@@ -15,7 +15,7 @@ class SpinButton(Gtk.SpinButton, BaseWidget):  # type: ignore
 
     .. code-block:: python
 
-        Widget.SpinButton(
+        widgets.SpinButton(
             min=0,
             max=100,
             step=1,

--- a/ignis/widgets/stack.py
+++ b/ignis/widgets/stack.py
@@ -11,7 +11,7 @@ class Stack(Gtk.Stack, BaseWidget):
     Stack is a container which only shows one of its children at a time.
 
     It does not provide a means for users to change the visible child.
-    Instead, a separate widget such as :class:`~ignis.widgets.Widget.StackSwitcher` can be used with Stack to provide this functionality.
+    Instead, a separate widget such as :class:`~ignis.widgets.StackSwitcher` can be used with Stack to provide this functionality.
 
     Args:
         **kwargs: Properties to set.
@@ -21,26 +21,26 @@ class Stack(Gtk.Stack, BaseWidget):
 
     .. code-block:: python
 
-        from ignis.widgets import Widget
+        from ignis import widgets
 
-        stack = Widget.Stack(
+        stack = widgets.Stack(
             child=[
-                Widget.StackPage(
-                    title="page 1", child=Widget.Label(label="welcome to page 1!")
+                widgets.StackPage(
+                    title="page 1", child=widgets.Label(label="welcome to page 1!")
                 ),
-                Widget.StackPage(
-                    title="page 2", child=Widget.Label(label="welcome to page 2!")
+                widgets.StackPage(
+                    title="page 2", child=widgets.Label(label="welcome to page 2!")
                 ),
-                Widget.StackPage(
-                    title="page 3", child=Widget.Label(label="welcome to page 3!")
+                widgets.StackPage(
+                    title="page 3", child=widgets.Label(label="welcome to page 3!")
                 ),
             ]
         )
 
-        Widget.Box(
+        widgets.Box(
             vertical=True,
             # you should add both StackSwitcher and Stack.
-            child=[Widget.StackSwitcher(stack=stack), stack],
+            child=[widgets.StackSwitcher(stack=stack), stack],
         )
     """
 

--- a/ignis/widgets/stack_page.py
+++ b/ignis/widgets/stack_page.py
@@ -7,10 +7,10 @@ class StackPage(IgnisGObject):
     """
     Bases: :class:`~ignis.gobject.IgnisGObject`
 
-    Intented to use with :class:`~ignis.widgets.Widget.Stack`.
+    Intented to use with :class:`~ignis.widgets.Stack`.
 
     Args:
-        title: The title. It will be used by :class:`~ignis.widgets.Widget.StackSwitcher` to display :attr:`child` in a tab bar.
+        title: The title. It will be used by :class:`~ignis.widgets.StackSwitcher` to display :attr:`child` in a tab bar.
         child: The child widget.
 
     .. warning::
@@ -26,7 +26,7 @@ class StackPage(IgnisGObject):
     def title(self) -> str:
         """
         The title.
-        It will be used by :class:`~ignis.widgets.Widget.StackSwitcher` to display :attr:`child` in a tab bar.
+        It will be used by :class:`~ignis.widgets.StackSwitcher` to display :attr:`child` in a tab bar.
         """
         return self._title
 

--- a/ignis/widgets/stack_switcher.py
+++ b/ignis/widgets/stack_switcher.py
@@ -6,7 +6,7 @@ class StackSwitcher(Gtk.StackSwitcher, BaseWidget):
     """
     Bases: :class:`Gtk.StackSwitcher`
 
-    The StackSwitcher shows a row of buttons to switch between :class:`~ignis.widgets.Widget.Stack` pages.
+    The StackSwitcher shows a row of buttons to switch between :class:`~ignis.widgets.Stack` pages.
 
     Args:
         **kwargs: Properties to set.

--- a/ignis/widgets/switch.py
+++ b/ignis/widgets/switch.py
@@ -16,7 +16,7 @@ class Switch(Gtk.Switch, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Switch(
+        widgets.Switch(
             active=True,
             on_change=lambda x, active: print(active),
         )

--- a/ignis/widgets/toggle_button.py
+++ b/ignis/widgets/toggle_button.py
@@ -15,7 +15,7 @@ class ToggleButton(Gtk.ToggleButton, BaseWidget):
 
     .. code-block:: python
 
-        Widget.ToggleButton(
+        widgets.ToggleButton(
             on_toggled=lambda x, active: print(active)
         )
     """

--- a/ignis/widgets/window.py
+++ b/ignis/widgets/window.py
@@ -54,18 +54,18 @@ class Window(Gtk.Window, BaseWidget):
         **kwargs: Properties to set.
 
     .. warning::
-        Applying CSS styles directly to ``Widget.Window`` can cause various graphical glitches/bugs.
-        It's highly recommended to set some container (for example, ``Widget.Box``) or widget as a child and apply styles to it.
+        Applying CSS styles directly to ``widgets.Window`` can cause various graphical glitches/bugs.
+        It's highly recommended to set some container (for example, ``widgets.Box``) or widget as a child and apply styles to it.
         For example:
 
         .. code-block:: python
 
-            from ignis.widgets import Widget
+            from ignis import widgets
 
-            Widget.Window(
+            widgets.Window(
                 namespace="some-window",
                 # css_classes=['test-window'],  # don't do this!
-                child=Widget.Box(
+                child=widgets.Box(
                     css_classes=['test-window'],  # use this instead
                     child=[...]
                 )
@@ -76,9 +76,9 @@ class Window(Gtk.Window, BaseWidget):
 
     .. code-block:: python
 
-        Widget.Window(
+        widgets.Window(
             namespace="example_window",
-            child=Widget.Label(label='heh'),
+            child=widgets.Label(label='heh'),
             monitor=0,
             anchor=["top", "right"],
             exclusive=True,


### PR DESCRIPTION
The continuation of #226, I just have taken it over.

This pull request explicitly exports widgets in the `ignis.widgets` package, which makes the universal `Widget` class unnecessary.

## Motivation

The current `Widget` class is a bit unconventional for Python. Sometimes code editors LSP's get confused because of it and simply don't provide autocompletion.

To be true, the actual reason why I do it right now is because I am working on `ignis-stubs-gen`. The generated stubs are processed by Ruff (check + fix) and it removes almost all imports from `ignis/widgets/__init__.py`, because it see them as _unused_,

## Breaking Changes

I know it is painfully to hear, but now the `Widget` class is deprecated (but not removed), and you have to use `from ignis import widgets` instead.

To ease moving from it, use search & replace in your code editor:

> [!DANGER]
> Make sure you made a backup of your configuration!

1. Replace: `from ignis.widgets import Widget` -> `from ignis import widgets`
2. Replace `Widget.` -> `widgets.`  (double-check that you're replacing, something extra may be matched)

Alternatively, you can import `ignis.widgets` as `Widget` by using this:

```python
from ignis import widgets as Widget
```

...or this:

```python
import ignis.widgets as Widget
```

> [!NOTE]
> `from ignis import widgets` is more preferred and will be used in the documentation and examples