### PR TITLE
feat!: export utils

### DIFF
--- a/docs/api/utils/FileMonitor.rst
+++ b/docs/api/utils/FileMonitor.rst
@@ -1,5 +1,5 @@
 FileMonitor
 ===========
 
-.. autoclass:: ignis.utils.Utils.FileMonitor
+.. autoclass:: ignis.utils.FileMonitor
     :members:

--- a/docs/api/utils/Poll.rst
+++ b/docs/api/utils/Poll.rst
@@ -1,5 +1,5 @@
 Poll
 ====
 
-.. autoclass:: ignis.utils.Utils.Poll
+.. autoclass:: ignis.utils.Poll
     :members:

--- a/docs/api/utils/Timeout.rst
+++ b/docs/api/utils/Timeout.rst
@@ -1,5 +1,5 @@
 Timeout
 =======
 
-.. autoclass:: ignis.utils.Utils.Timeout
+.. autoclass:: ignis.utils.Timeout
     :members:

--- a/docs/api/utils/debounce.rst
+++ b/docs/api/utils/debounce.rst
@@ -1,6 +1,6 @@
 Debounce
 ========
 
-.. autoclass:: ignis.utils.Utils.DebounceTask
+.. autoclass:: ignis.utils.DebounceTask
 
-.. autofunction:: ignis.utils.Utils.debounce
+.. autofunction:: ignis.utils.debounce

--- a/docs/api/utils/file.rst
+++ b/docs/api/utils/file.rst
@@ -1,10 +1,10 @@
 File
 ====
 
-.. autofunction:: ignis.utils.Utils.read_file
+.. autofunction:: ignis.utils.read_file
 
-.. autofunction:: ignis.utils.Utils.read_file_async
+.. autofunction:: ignis.utils.read_file_async
 
-.. autofunction:: ignis.utils.Utils.write_file
+.. autofunction:: ignis.utils.write_file
 
-.. autofunction:: ignis.utils.Utils.write_file_async
+.. autofunction:: ignis.utils.write_file_async

--- a/docs/api/utils/icon.rst
+++ b/docs/api/utils/icon.rst
@@ -1,8 +1,8 @@
 Icon
 ====
 
-.. autofunction:: ignis.utils.Utils.get_file_icon_name
+.. autofunction:: ignis.utils.get_file_icon_name
 
-.. autofunction:: ignis.utils.Utils.get_paintable
+.. autofunction:: ignis.utils.get_paintable
 
-.. autofunction:: ignis.utils.Utils.get_app_icon_name
+.. autofunction:: ignis.utils.get_app_icon_name

--- a/docs/api/utils/index.rst
+++ b/docs/api/utils/index.rst
@@ -3,13 +3,13 @@ Utils
 
 There is a list of utilities—useful tools that can help you.
 
-Use the universal ``Utils`` class to access them:
+Use the ``ignis.utils`` package to access them:
 
 .. code-block:: python
 
-   from ignis.utils import Utils
+   from ignis import utils
 
-   Utils.NAME()
+   utils.NAME()
 
 .. toctree:: 
    :glob:

--- a/docs/api/utils/misc.rst
+++ b/docs/api/utils/misc.rst
@@ -1,6 +1,6 @@
 Misc
 ====
 
-.. autofunction:: ignis.utils.Utils.get_current_dir
+.. autofunction:: ignis.utils.get_current_dir
 
-.. autofunction:: ignis.utils.Utils.load_interface_xml
+.. autofunction:: ignis.utils.load_interface_xml

--- a/docs/api/utils/monitor.rst
+++ b/docs/api/utils/monitor.rst
@@ -1,8 +1,8 @@
 Monitor
 =======
 
-.. autofunction:: ignis.utils.Utils.get_monitor
+.. autofunction:: ignis.utils.get_monitor
 
-.. autofunction:: ignis.utils.Utils.get_monitors
+.. autofunction:: ignis.utils.get_monitors
 
-.. autofunction:: ignis.utils.Utils.get_n_monitors
+.. autofunction:: ignis.utils.get_n_monitors

--- a/docs/api/utils/pixbuf.rst
+++ b/docs/api/utils/pixbuf.rst
@@ -1,6 +1,6 @@
 Pixbuf
 ======
 
-.. autofunction:: ignis.utils.Utils.crop_pixbuf
+.. autofunction:: ignis.utils.crop_pixbuf
 
-.. autofunction:: ignis.utils.Utils.scale_pixbuf
+.. autofunction:: ignis.utils.scale_pixbuf

--- a/docs/api/utils/sass.rst
+++ b/docs/api/utils/sass.rst
@@ -1,4 +1,4 @@
 Sass
 ====
 
-.. autofunction:: ignis.utils.Utils.sass_compile
+.. autofunction:: ignis.utils.sass_compile

--- a/docs/api/utils/sh.rst
+++ b/docs/api/utils/sh.rst
@@ -1,9 +1,9 @@
 Shell Commands
 ==============
 
-.. autofunction:: ignis.utils.Utils.exec_sh
+.. autofunction:: ignis.utils.exec_sh
 
-.. autofunction:: ignis.utils.Utils.exec_sh_async
+.. autofunction:: ignis.utils.exec_sh_async
 
-.. autoclass:: ignis.utils.Utils.AsyncCompletedProcess
+.. autoclass:: ignis.utils.AsyncCompletedProcess
     :members:

--- a/docs/api/utils/socket.rst
+++ b/docs/api/utils/socket.rst
@@ -1,6 +1,6 @@
 Socket
 ======
 
-.. autofunction:: ignis.utils.Utils.listen_socket
+.. autofunction:: ignis.utils.listen_socket
 
-.. autofunction:: ignis.utils.Utils.send_socket
+.. autofunction:: ignis.utils.send_socket

--- a/docs/api/utils/str_cases.rst
+++ b/docs/api/utils/str_cases.rst
@@ -1,6 +1,6 @@
 String Cases
 ============
 
-.. autofunction:: ignis.utils.Utils.snake_to_pascal
+.. autofunction:: ignis.utils.snake_to_pascal
 
-.. autofunction:: ignis.utils.Utils.pascal_to_snake
+.. autofunction:: ignis.utils.pascal_to_snake

--- a/docs/api/utils/thread.rst
+++ b/docs/api/utils/thread.rst
@@ -1,9 +1,9 @@
 Thread
 ======
 
-.. autofunction:: ignis.utils.Utils.thread
+.. autofunction:: ignis.utils.thread
 
-.. autofunction:: ignis.utils.Utils.run_in_thread
+.. autofunction:: ignis.utils.run_in_thread
 
-.. autoclass:: ignis.utils.Utils.ThreadTask
+.. autoclass:: ignis.utils.ThreadTask
     :members:

--- a/docs/api/utils/version.rst
+++ b/docs/api/utils/version.rst
@@ -1,10 +1,10 @@
 Version
 =======
 
-.. autofunction:: ignis.utils.Utils.get_ignis_version
+.. autofunction:: ignis.utils.get_ignis_version
 
-.. autofunction:: ignis.utils.Utils.get_ignis_commit
+.. autofunction:: ignis.utils.get_ignis_commit
 
-.. autofunction:: ignis.utils.Utils.get_ignis_branch
+.. autofunction:: ignis.utils.get_ignis_branch
 
-.. autofunction:: ignis.utils.Utils.get_ignis_commit_msg
+.. autofunction:: ignis.utils.get_ignis_commit_msg

--- a/docs/examples/code_snippets.rst
+++ b/docs/examples/code_snippets.rst
@@ -76,7 +76,7 @@ Display applications icons on Hyprland workspaces buttons
                     "windows",
                     lambda _: [
                         # find the icon of the app by its class name
-                        Widget.Icon(icon_name=Utils.get_app_icon_name(window.class_name))
+                        Widget.Icon(icon_name=utils.get_app_icon_name(window.class_name))
                         # get all windows on the current workspace
                         for window in hyprland.get_windows_on_workspace(
                             workspace_id=workspace.id

--- a/docs/user/async.rst
+++ b/docs/user/async.rst
@@ -21,9 +21,9 @@ Use :func:`asyncio.create_task` to schedule execution.
 .. code-block:: python
     
     import asyncio
-    from ignis.utils import Utils
+    from ignis import utils
 
-    asyncio.create_task(Utils.exec_sh_async("notify-send 'asynchrony!'"))
+    asyncio.create_task(utils.exec_sh_async("notify-send 'asynchrony!'"))
 
 2. From another asynchronous function
 
@@ -32,10 +32,10 @@ Use the ``await`` keyword to wait for execution.
 .. code-block:: python
     
     import asyncio
-    from ignis.utils import Utils
+    from ignis import utils
 
     async def some_func() -> None:
-        await Utils.exec_sh_async("notify-send 'asynchrony!'")
+        await utils.exec_sh_async("notify-send 'asynchrony!'")
 
     # you still need create_task() because some_func is async
     asyncio.create_task(some_func())

--- a/docs/user/dynamic_content.rst
+++ b/docs/user/dynamic_content.rst
@@ -7,7 +7,7 @@ Static text can be boring, so let's add some dynamic elements!
 
     import datetime
     from ignis.widgets import Widget
-    from ignis.utils import Utils
+    from ignis import utils
 
     def update_label(clock_label: Widget.Label) -> None:
         text = datetime.datetime.now().strftime("%H:%M:%S")
@@ -16,7 +16,7 @@ Static text can be boring, so let's add some dynamic elements!
     def bar(monitor: int) -> Widget.Window:
         clock_label = Widget.Label()
 
-        Utils.Poll(1000, lambda x: update_label(clock_label))
+        utils.Poll(1000, lambda x: update_label(clock_label))
 
         return Widget.Window(
             namespace=f"some-window-{monitor}",

--- a/examples/bar/config.py
+++ b/examples/bar/config.py
@@ -2,7 +2,7 @@ import datetime
 import asyncio
 from ignis.menu_model import IgnisMenuModel, IgnisMenuItem, IgnisMenuSeparator
 from ignis.widgets import Widget
-from ignis.utils import Utils
+from ignis import utils
 from ignis.app import IgnisApp
 from ignis.services.audio import AudioService
 from ignis.services.system_tray import SystemTrayService, SystemTrayItem
@@ -13,7 +13,7 @@ from ignis.services.mpris import MprisService, MprisPlayer
 
 app = IgnisApp.get_default()
 
-app.apply_css(f"{Utils.get_current_dir()}/style.scss")
+app.apply_css(f"{utils.get_current_dir()}/style.scss")
 
 
 audio = AudioService.get_default()
@@ -202,7 +202,7 @@ def clock() -> Widget.Label:
     # poll for current time every second
     return Widget.Label(
         css_classes=["clock"],
-        label=Utils.Poll(
+        label=utils.Poll(
             1_000, lambda self: datetime.datetime.now().strftime("%H:%M")
         ).bind("output"),
     )
@@ -287,7 +287,7 @@ def speaker_slider() -> Widget.Scale:
 
 def create_exec_task(cmd: str) -> None:
     # use create_task to run async function in a regular (sync) one
-    asyncio.create_task(Utils.exec_sh_async(cmd))
+    asyncio.create_task(utils.exec_sh_async(cmd))
 
 
 def logout() -> None:
@@ -372,7 +372,7 @@ def right() -> Widget.Box:
 
 
 def bar(monitor_id: int = 0) -> Widget.Window:
-    monitor_name = Utils.get_monitor(monitor_id).get_connector()  # type: ignore
+    monitor_name = utils.get_monitor(monitor_id).get_connector()  # type: ignore
     return Widget.Window(
         namespace=f"ignis_bar_{monitor_id}",
         monitor=monitor_id,
@@ -388,5 +388,5 @@ def bar(monitor_id: int = 0) -> Widget.Window:
 
 
 # this will display bar on all monitors
-for i in range(Utils.get_n_monitors()):
+for i in range(utils.get_n_monitors()):
     bar(i)

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -5,7 +5,7 @@ import datetime
 from dataclasses import dataclass
 from typing import Literal
 from ignis.dbus import DBusService
-from ignis.utils import Utils
+from ignis import utils
 from loguru import logger
 from gi.repository import Gtk, Gdk, Gio, GLib  # type: ignore
 from ignis.gobject import IgnisGObject, IgnisProperty, IgnisSignal
@@ -79,7 +79,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         self.__dbus = DBusService(
             name="com.github.linkfrg.ignis",
             object_path="/com/github/linkfrg/ignis",
-            info=Utils.load_interface_xml("com.github.linkfrg.ignis"),
+            info=utils.load_interface_xml("com.github.linkfrg.ignis"),
         )
 
         self.__dbus.register_dbus_method(name="OpenWindow", method=self.__OpenWindow)
@@ -104,7 +104,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         self._widgets_style_priority: StylePriority = "application"
 
     def __watch_config(
-        self, file_monitor: Utils.FileMonitor, path: str, event_type: str
+        self, file_monitor: utils.FileMonitor, path: str, event_type: str
     ) -> None:
         if event_type != "changes_done_hint":
             return
@@ -122,7 +122,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
                 logger.info("Monitors have changed, reloading.")
                 self.reload()
 
-        monitors = Utils.get_monitors()
+        monitors = utils.get_monitors()
         monitors.connect("items-changed", callback)
 
     @classmethod
@@ -271,7 +271,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
             )
 
         if style_path.endswith(".scss") or style_path.endswith(".sass"):
-            css_style = Utils.sass_compile(path=style_path, compiler=compiler)
+            css_style = utils.sass_compile(path=style_path, compiler=compiler)
         elif style_path.endswith(".css"):
             with open(style_path) as file:
                 css_style = file.read()
@@ -382,12 +382,12 @@ class IgnisApp(Gtk.Application, IgnisGObject):
 
         .. code-block:: python
 
-            from ignis.utils import Utils
+            from ignis import utils
             from ignis.app import IgnisApp
 
             app = IgnisApp.get_default()
 
-            app.add_icons(f"{Utils.get_current_dir()}/icons")
+            app.add_icons(f"{utils.get_current_dir()}/icons")
         """
         display = Gdk.Display.get_default()
 
@@ -417,7 +417,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
 
         logger.info(f"Using configuration file: {self._config_path}")
 
-        self._monitor = Utils.FileMonitor(
+        self._monitor = utils.FileMonitor(
             path=config_dir, callback=self.__watch_config, recursive=True
         )
 

--- a/ignis/cli.py
+++ b/ignis/cli.py
@@ -2,7 +2,7 @@ import os
 import typer
 import subprocess
 from ignis.client import IgnisClient
-from ignis.utils import Utils
+from ignis import utils
 from ignis.exceptions import WindowNotFoundError
 from typing import Any
 from ignis import is_editable_install, is_sphinx_build
@@ -43,21 +43,21 @@ def _run_git_cmd(args: str) -> str | None:
 
 def get_version_message() -> str:
     if not is_editable_install:
-        return f"""Ignis {Utils.get_ignis_version()}
-Branch: {Utils.get_ignis_branch()}
-Commit: {Utils.get_ignis_commit()} ({Utils.get_ignis_commit_msg()})"""
+        return f"""Ignis {utils.get_ignis_version()}
+Branch: {utils.get_ignis_branch()}
+Commit: {utils.get_ignis_commit()} ({utils.get_ignis_commit_msg()})"""
     else:
         commit = _run_git_cmd("rev-parse HEAD")
         branch = _run_git_cmd("branch --show-current")
         commit_msg = _run_git_cmd("log -1 --pretty=%B")
-        return f"""Ignis {Utils.get_ignis_version()}
+        return f"""Ignis {utils.get_ignis_version()}
 Editable install
 Branch: {branch}
 Commit: {commit} ({commit_msg})
 
 Version at the moment of the installation:
-Branch: {Utils.get_ignis_branch()}
-Commit: {Utils.get_ignis_commit()} ({Utils.get_ignis_commit_msg()})
+Branch: {utils.get_ignis_branch()}
+Commit: {utils.get_ignis_commit()} ({utils.get_ignis_commit_msg()})
 """
 
 

--- a/ignis/client.py
+++ b/ignis/client.py
@@ -1,5 +1,5 @@
 from ignis.dbus import DBusProxy
-from ignis.utils import Utils
+from ignis import utils
 from ignis.exceptions import WindowNotFoundError, IgnisNotRunningError
 from typing import Any
 
@@ -34,7 +34,7 @@ class IgnisClient:
             name="com.github.linkfrg.ignis",
             object_path="/com/github/linkfrg/ignis",
             interface_name="com.github.linkfrg.ignis",
-            info=Utils.load_interface_xml("com.github.linkfrg.ignis"),
+            info=utils.load_interface_xml("com.github.linkfrg.ignis"),
         )
 
     @property

--- a/ignis/dbus.py
+++ b/ignis/dbus.py
@@ -2,7 +2,7 @@ import asyncio
 from gi.repository import Gio, GLib  # type: ignore
 from typing import Any, overload
 from collections.abc import Callable
-from ignis.utils import Utils
+from ignis import utils
 from ignis.gobject import IgnisGObject, IgnisProperty
 from ignis.exceptions import DBusMethodNotFoundError, DBusPropertyNotFoundError
 from typing import Literal
@@ -17,7 +17,7 @@ class DBusService(IgnisGObject):
     Args:
         name: The well-known name to own.
         object_path: An object path.
-        info: An instance of :class:`Gio.DBusInterfaceInfo`. You can get it from XML using :func:`~ignis.utils.Utils.load_interface_xml`.
+        info: An instance of :class:`Gio.DBusInterfaceInfo`. You can get it from XML using :func:`~ignis.utils.utils.load_interface_xml`.
         on_name_acquired: The function to call when ``name`` is acquired.
         on_name_lost: The function to call when ``name`` is lost.
 
@@ -85,7 +85,7 @@ class DBusService(IgnisGObject):
         """
         An instance of :class:`Gio.DBusInterfaceInfo`
 
-        You can get it from XML using :func:`~ignis.utils.Utils.load_interface_xml`.
+        You can get it from XML using :func:`~ignis.utils.utils.load_interface_xml`.
         """
         return self._info
 
@@ -163,7 +163,7 @@ class DBusService(IgnisGObject):
         # params can contain pixbuf, very large amount of data
         # and unpacking may take some time and block the main thread
         # so we unpack in another thread, and call DBus method when unpacking is finished
-        Utils.ThreadTask(
+        utils.ThreadTask(
             target=params.unpack, callback=lambda result: callback(func, result)
         ).run()
 
@@ -313,7 +313,7 @@ class DBusProxy(IgnisGObject):
             name: A bus name (well-known or unique).
             object_path: An object path.
             interface_name: A D-Bus interface name.
-            info: A :class:`Gio.DBusInterfaceInfo` instance. You can get it from XML using :class:`~ignis.utils.Utils.load_interface_xml`.
+            info: A :class:`Gio.DBusInterfaceInfo` instance. You can get it from XML using :class:`~ignis.utils.utils.load_interface_xml`.
             bus_type: The type of the bus.
         """
         gproxy = Gio.DBusProxy.new_for_bus_sync(
@@ -343,7 +343,7 @@ class DBusProxy(IgnisGObject):
             name: A bus name (well-known or unique).
             object_path: An object path.
             interface_name: A D-Bus interface name.
-            info: A :class:`Gio.DBusInterfaceInfo` instance. You can get it from XML using :class:`~ignis.utils.Utils.load_interface_xml`.
+            info: A :class:`Gio.DBusInterfaceInfo` instance. You can get it from XML using :class:`~ignis.utils.utils.load_interface_xml`.
             bus_type: The type of the bus.
             callback: A function to call when the initialization is complete. The function will receive a newly initialized instance of this class.
             *user_data: User data to pass to ``callback``.
@@ -386,7 +386,7 @@ class DBusProxy(IgnisGObject):
         """
         A :class:`Gio.DBusInterfaceInfo` instance.
 
-        You can get it from XML using :class:`~ignis.utils.Utils.load_interface_xml`.
+        You can get it from XML using :class:`~ignis.utils.utils.load_interface_xml`.
         """
         return self._gproxy.props.g_interface_info
 
@@ -434,7 +434,7 @@ class DBusProxy(IgnisGObject):
             name="org.freedesktop.DBus",
             object_path="/org/freedesktop/DBus",
             interface_name="org.freedesktop.DBus",
-            info=Utils.load_interface_xml("org.freedesktop.DBus"),
+            info=utils.load_interface_xml("org.freedesktop.DBus"),
             bus_type=self.bus_type,
         )
         return dbus.NameHasOwner("(s)", self.name)

--- a/ignis/dbus_menu.py
+++ b/ignis/dbus_menu.py
@@ -2,7 +2,7 @@ import asyncio
 import weakref
 from gi.repository import Gtk, GLib  # type: ignore
 from ignis.dbus import DBusProxy
-from ignis.utils import Utils
+from ignis import utils
 from ignis.gobject import IgnisProperty
 from ignis.menu_model import (
     IgnisMenuModel,
@@ -103,7 +103,7 @@ class DBusMenu(Gtk.PopoverMenu):
             name=name,
             object_path=object_path,
             interface_name="com.canonical.dbusmenu",
-            info=Utils.load_interface_xml("com.canonical.dbusmenu"),
+            info=utils.load_interface_xml("com.canonical.dbusmenu"),
         )
         obj = cls(proxy)
         layout = proxy.GetLayout(*DBUS_GET_LAYOUT_ARGS)
@@ -125,7 +125,7 @@ class DBusMenu(Gtk.PopoverMenu):
             name=name,
             object_path=object_path,
             interface_name="com.canonical.dbusmenu",
-            info=Utils.load_interface_xml("com.canonical.dbusmenu"),
+            info=utils.load_interface_xml("com.canonical.dbusmenu"),
         )
         obj = cls(proxy)
         layout = await proxy.GetLayoutAsync(*DBUS_GET_LAYOUT_ARGS)

--- a/ignis/options_manager.py
+++ b/ignis/options_manager.py
@@ -1,6 +1,6 @@
 import json
 from ignis.gobject import IgnisGObject, Binding, IgnisProperty, IgnisSignal
-from ignis.utils import Utils
+from ignis import utils
 from typing import Any, TypeVar
 from collections.abc import Callable
 from collections.abc import Generator
@@ -360,7 +360,7 @@ class OptionsManager(OptionsGroup):
             self.load_from_file(self._file, emit=False)
 
             if hot_reload:
-                Utils.FileMonitor(path=self._file, callback=self.__hot_reload)
+                utils.FileMonitor(path=self._file, callback=self.__hot_reload)
 
     def __hot_reload(self, x, path: str, event_type: str) -> None:
         if not self._file:

--- a/ignis/services/backlight/device.py
+++ b/ignis/services/backlight/device.py
@@ -1,6 +1,6 @@
 import os
 from ignis.gobject import IgnisGObject, IgnisProperty
-from ignis.utils import Utils
+from ignis import utils
 from ignis.dbus import DBusProxy
 from .constants import SYS_BACKLIGHT
 from .util import get_session_path
@@ -27,7 +27,7 @@ class BacklightDevice(IgnisGObject):
         with open(self._PATH_TO_MAX_BRIGHTNESS) as backlight_file:
             self._max_brightness = int(backlight_file.read().strip())
 
-        Utils.FileMonitor(
+        utils.FileMonitor(
             path=self._PATH_TO_BRIGHTNESS,
             callback=lambda x, path, event_type: self.__sync_brightness()
             if event_type != "changed"  # "changed" event is called multiple times
@@ -37,7 +37,7 @@ class BacklightDevice(IgnisGObject):
         self.__session_proxy = DBusProxy.new(
             name="org.freedesktop.login1",
             object_path=get_session_path(),
-            info=Utils.load_interface_xml("org.freedesktop.login1.Session"),
+            info=utils.load_interface_xml("org.freedesktop.login1.Session"),
             interface_name="org.freedesktop.login1.Session",
             bus_type="system",
         )

--- a/ignis/services/backlight/service.py
+++ b/ignis/services/backlight/service.py
@@ -2,7 +2,7 @@ import os
 from ignis.base_service import BaseService
 from .device import BacklightDevice
 from .constants import SYS_BACKLIGHT
-from ignis.utils import Utils
+from ignis import utils
 from ignis.gobject import IgnisProperty
 
 
@@ -34,7 +34,7 @@ class BacklightService(BaseService):
         self._devices: list[BacklightDevice] = []
 
         # FIXME: not working
-        Utils.FileMonitor(
+        utils.FileMonitor(
             path=SYS_BACKLIGHT,
             callback=lambda x, path, event_type: self.__sync_devices()
             if event_type == "deleted" or event_type == "created"

--- a/ignis/services/backlight/util.py
+++ b/ignis/services/backlight/util.py
@@ -1,13 +1,13 @@
 import os
 from ignis.dbus import DBusProxy
-from ignis.utils import Utils
+from ignis import utils
 
 
 def get_session_path() -> str:
     proxy = DBusProxy.new(
         name="org.freedesktop.login1",
         object_path="/org/freedesktop/login1",
-        info=Utils.load_interface_xml("org.freedesktop.login1.Manager"),
+        info=utils.load_interface_xml("org.freedesktop.login1.Manager"),
         interface_name="org.freedesktop.login1.Manager",
         bus_type="system",
     )

--- a/ignis/services/fetch/service.py
+++ b/ignis/services/fetch/service.py
@@ -163,7 +163,7 @@ class FetchService(BaseService):
         """
         The current uptime (days, hours, minutes, seconds).
 
-        You can use :class:`~ignis.utils.Utils.Poll` to get the current uptime every minute or second.
+        You can use :class:`~ignis.utils.utils.Poll` to get the current uptime every minute or second.
         """
         with open("/proc/uptime") as f:
             uptime_seconds = float(f.readline().split()[0])

--- a/ignis/services/hyprland/service.py
+++ b/ignis/services/hyprland/service.py
@@ -2,7 +2,7 @@ import json
 import os
 import socket
 from typing import Any, Literal
-from ignis.utils import Utils
+from ignis import utils
 from ignis.exceptions import HyprlandIPCNotFoundError
 from ignis.base_service import BaseService
 from ignis.gobject import IgnisProperty, IgnisSignal
@@ -178,11 +178,11 @@ class HyprlandService(BaseService):
         """
         return list(self._monitors.values())
 
-    @Utils.run_in_thread
+    @utils.run_in_thread
     def __listen_events(self) -> None:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
             sock.connect(f"{HYPR_SOCKET_DIR}/.socket2.sock")
-            for event in Utils.listen_socket(sock, errors="ignore"):
+            for event in utils.listen_socket(sock, errors="ignore"):
                 self.__on_event_received(event)
 
     def __on_event_received(self, event: str) -> None:
@@ -446,7 +446,7 @@ class HyprlandService(BaseService):
 
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
             sock.connect(f"{HYPR_SOCKET_DIR}/.socket.sock")
-            return Utils.send_socket(sock, cmd, errors="ignore")
+            return utils.send_socket(sock, cmd, errors="ignore")
 
     def switch_to_workspace(self, workspace_id: int) -> None:
         """

--- a/ignis/services/mpris/player.py
+++ b/ignis/services/mpris/player.py
@@ -3,7 +3,7 @@ import asyncio
 from ignis.dbus import DBusProxy
 from gi.repository import GLib  # type: ignore
 from ignis.gobject import IgnisGObject, IgnisProperty, IgnisSignal
-from ignis.utils import Utils
+from ignis import utils
 from ignis.connection_manager import ConnectionManager
 from collections.abc import Callable
 from .constants import ART_URL_CACHE_DIR
@@ -69,14 +69,14 @@ class MprisPlayer(IgnisGObject):
             name=name,
             object_path="/org/mpris/MediaPlayer2",
             interface_name="org.mpris.MediaPlayer2",
-            info=Utils.load_interface_xml("org.mpris.MediaPlayer2"),
+            info=utils.load_interface_xml("org.mpris.MediaPlayer2"),
         )
 
         player_proxy = await DBusProxy.new_async(
             name=name,
             object_path="/org/mpris/MediaPlayer2",
             interface_name="org.mpris.MediaPlayer2.Player",
-            info=Utils.load_interface_xml("org.mpris.MediaPlayer2.Player"),
+            info=utils.load_interface_xml("org.mpris.MediaPlayer2.Player"),
         )
 
         obj = cls(mpris_proxy=mpris_proxy, player_proxy=player_proxy)
@@ -97,7 +97,7 @@ class MprisPlayer(IgnisGObject):
 
     async def __sync_property(self, proxy: DBusProxy, py_name: str) -> None:
         try:
-            value = await proxy.get_dbus_property_async(Utils.snake_to_pascal(py_name))
+            value = await proxy.get_dbus_property_async(utils.snake_to_pascal(py_name))
         except GLib.Error:
             return
 
@@ -179,8 +179,8 @@ class MprisPlayer(IgnisGObject):
         if os.path.exists(path):
             return path
 
-        contents = await Utils.read_file_async(uri=art_url, decode=False)
-        await Utils.write_file_async(path=path, contents=contents)
+        contents = await utils.read_file_async(uri=art_url, decode=False)
+        await utils.write_file_async(path=path, contents=contents)
         return path
 
     async def __update_position(self) -> None:

--- a/ignis/services/mpris/service.py
+++ b/ignis/services/mpris/service.py
@@ -1,6 +1,6 @@
 import asyncio
 from ignis.dbus import DBusProxy
-from ignis.utils import Utils
+from ignis import utils
 from ignis.base_service import BaseService
 from ignis.gobject import IgnisProperty, IgnisSignal
 from .player import MprisPlayer
@@ -29,7 +29,7 @@ class MprisService(BaseService):
             name="org.freedesktop.DBus",
             object_path="/org/freedesktop/DBus",
             interface_name="org.freedesktop.DBus",
-            info=Utils.load_interface_xml("org.freedesktop.DBus"),
+            info=utils.load_interface_xml("org.freedesktop.DBus"),
         )
 
         self.__dbus.signal_subscribe(

--- a/ignis/services/niri/service.py
+++ b/ignis/services/niri/service.py
@@ -1,7 +1,7 @@
 import json
 import os
 import socket
-from ignis.utils import Utils
+from ignis import utils
 from ignis.exceptions import NiriIPCNotFoundError
 from ignis.base_service import BaseService
 from ignis.gobject import IgnisProperty, IgnisSignal
@@ -128,7 +128,7 @@ class NiriService(BaseService):
         # it is received, we are ready to launch a threaded (non blocking) version.
         self.__listen_events(sock=sock, break_on="OverviewOpenedOrClosed")
 
-        Utils.thread(lambda: self.__listen_events(sock=sock))
+        utils.thread(lambda: self.__listen_events(sock=sock))
         # No need to send any other commands after event stream initialization:
         #
         #  "The event stream IPC is designed to give you the complete current
@@ -138,7 +138,7 @@ class NiriService(BaseService):
         #   - https://github.com/YaLTeR/niri/wiki/IPC
 
     def __listen_events(self, sock: socket.socket, break_on: str = "") -> None:
-        for event in Utils.listen_socket(sock, errors="ignore"):
+        for event in utils.listen_socket(sock, errors="ignore"):
             json_data = json.loads(event)
             event_type = list(json_data.keys())[0]
             event_data = list(json_data.values())[0]
@@ -343,7 +343,7 @@ class NiriService(BaseService):
 
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
             sock.connect(NIRI_SOCKET)
-            return Utils.send_socket(
+            return utils.send_socket(
                 sock, json.dumps(cmd) + "\n", errors="ignore", end_char="\n"
             )
 

--- a/ignis/services/notifications/notification.py
+++ b/ignis/services/notifications/notification.py
@@ -1,5 +1,5 @@
 from ignis.dbus import DBusService
-from ignis.utils import Utils
+from ignis import utils
 from ignis.gobject import IgnisGObject, IgnisProperty, IgnisSignal
 from .action import NotificationAction
 
@@ -46,7 +46,7 @@ class Notification(IgnisGObject):
             for i in range(0, len(actions), 2)
         ]
 
-        Utils.Timeout(timeout, self.dismiss)
+        utils.Timeout(timeout, self.dismiss)
 
     @IgnisSignal
     def closed(self):

--- a/ignis/services/notifications/service.py
+++ b/ignis/services/notifications/service.py
@@ -2,7 +2,7 @@ import os
 import json
 from ignis.dbus import DBusService, DBusProxy
 from gi.repository import GLib, GdkPixbuf  # type: ignore
-from ignis.utils import Utils
+from ignis import utils
 from loguru import logger
 from datetime import datetime
 from ignis.base_service import BaseService
@@ -45,7 +45,7 @@ class NotificationService(BaseService):
         self.__dbus = DBusService(
             name="org.freedesktop.Notifications",
             object_path="/org/freedesktop/Notifications",
-            info=Utils.load_interface_xml("org.freedesktop.Notifications"),
+            info=utils.load_interface_xml("org.freedesktop.Notifications"),
             on_name_lost=self.__on_name_lost,
         )
 
@@ -74,7 +74,7 @@ class NotificationService(BaseService):
             name="org.freedesktop.Notifications",
             interface_name="org.freedesktop.Notifications",
             object_path="/org/freedesktop/Notifications",
-            info=Utils.load_interface_xml("org.freedesktop.Notifications"),
+            info=utils.load_interface_xml("org.freedesktop.Notifications"),
         )
         try:
             info = proxy.GetServerInformation()

--- a/ignis/services/recorder/service.py
+++ b/ignis/services/recorder/service.py
@@ -39,14 +39,14 @@ class RecorderService(BaseService):
     .. code-block:: python
 
         from ignis.services.recorder import RecorderService
-        from ignis.utils import Utils
+        from ignis import utils
 
         recorder = RecorderService.get_default()
 
         recorder.start_recording(record_internal_audio=True)
 
         # record for 30 seconds and then stop
-        Utils.Timeout(ms=30 * 1000, target=recorder.stop_recording)
+        utils.Timeout(ms=30 * 1000, target=recorder.stop_recording)
     """
 
     def __init__(self):

--- a/ignis/services/recorder/session.py
+++ b/ignis/services/recorder/session.py
@@ -1,6 +1,6 @@
 from gi.repository import GLib  # type: ignore
 from ignis.dbus import DBusProxy
-from ignis.utils import Utils
+from ignis import utils
 from collections.abc import Callable
 
 
@@ -16,7 +16,7 @@ class SessionManager:
             name="org.freedesktop.portal.Desktop",
             object_path="/org/freedesktop/portal/desktop",
             interface_name="org.freedesktop.portal.ScreenCast",
-            info=Utils.load_interface_xml("org.freedesktop.portal.ScreenCast"),
+            info=utils.load_interface_xml("org.freedesktop.portal.ScreenCast"),
         )
 
         self._session_token_counter: int = 0
@@ -54,7 +54,7 @@ class SessionManager:
             name="org.freedesktop.portal.Desktop",
             object_path=request_path,
             interface_name="org.freedesktop.portal.Request",
-            info=Utils.load_interface_xml("org.freedesktop.portal.Request"),
+            info=utils.load_interface_xml("org.freedesktop.portal.Request"),
         )
 
         request_proxy.signal_subscribe(

--- a/ignis/services/system_tray/item.py
+++ b/ignis/services/system_tray/item.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import Literal
 from collections.abc import Callable
-from ignis.utils import Utils
+from ignis import utils
 from ignis.dbus import DBusProxy
 from gi.repository import GLib, GdkPixbuf, Gtk, Gdk  # type: ignore
 from ignis.gobject import IgnisGObject, IgnisProperty, IgnisSignal
@@ -77,7 +77,7 @@ class SystemTrayItem(IgnisGObject):
             name=name,
             object_path=object_path,
             interface_name="org.kde.StatusNotifierItem",
-            info=Utils.load_interface_xml("org.kde.StatusNotifierItem"),
+            info=utils.load_interface_xml("org.kde.StatusNotifierItem"),
         )
 
         if not proxy.has_owner:
@@ -114,7 +114,7 @@ class SystemTrayItem(IgnisGObject):
     async def __sync_property(self, py_name: str) -> None:
         try:
             value = await self._proxy.get_dbus_property_async(
-                Utils.snake_to_pascal(py_name)
+                utils.snake_to_pascal(py_name)
             )
         except GLib.Error:
             return

--- a/ignis/services/system_tray/service.py
+++ b/ignis/services/system_tray/service.py
@@ -1,5 +1,5 @@
 import asyncio
-from ignis.utils import Utils
+from ignis import utils
 from ignis.dbus import DBusService, DBusProxy
 from gi.repository import Gio, GLib  # type: ignore
 from ignis.base_service import BaseService
@@ -34,7 +34,7 @@ class SystemTrayService(BaseService):
         self.__dbus: DBusService = DBusService(
             name="org.kde.StatusNotifierWatcher",
             object_path="/StatusNotifierWatcher",
-            info=Utils.load_interface_xml("org.kde.StatusNotifierWatcher"),
+            info=utils.load_interface_xml("org.kde.StatusNotifierWatcher"),
             on_name_lost=self.__on_name_lost,
         )
 
@@ -59,7 +59,7 @@ class SystemTrayService(BaseService):
             name="org.kde.StatusNotifierWatcher",
             interface_name="org.kde.StatusNotifierWatcher",
             object_path="/StatusNotifierWatcher",
-            info=Utils.load_interface_xml("org.kde.StatusNotifierWatcher"),
+            info=utils.load_interface_xml("org.kde.StatusNotifierWatcher"),
         )
         name = proxy.gproxy.get_name_owner()
         raise AnotherSystemTrayRunningError(name)

--- a/ignis/services/systemd/service.py
+++ b/ignis/services/systemd/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import os
 from ignis.dbus import DBusProxy
-from ignis.utils import Utils
+from ignis import utils
 from ignis.base_service import BaseService
 from ignis.gobject import IgnisProperty
 from typing import Literal
@@ -45,7 +45,7 @@ class SystemdService(BaseService):
             name="org.freedesktop.systemd1",
             object_path="/org/freedesktop/systemd1",
             interface_name="org.freedesktop.systemd1.Manager",
-            info=Utils.load_interface_xml("org.freedesktop.systemd1.Manager"),
+            info=utils.load_interface_xml("org.freedesktop.systemd1.Manager"),
             bus_type=bus_type,
         )
 

--- a/ignis/services/systemd/unit.py
+++ b/ignis/services/systemd/unit.py
@@ -1,6 +1,6 @@
 from gi.repository import Gio, GLib  # type: ignore
 from ignis.dbus import DBusProxy
-from ignis.utils import Utils
+from ignis import utils
 from loguru import logger
 from ignis.gobject import IgnisGObject, IgnisProperty
 from typing import Literal
@@ -24,7 +24,7 @@ class SystemdUnit(IgnisGObject):
             name="org.freedesktop.systemd1",
             object_path=object_path,
             interface_name="org.freedesktop.systemd1.Unit",
-            info=Utils.load_interface_xml("org.freedesktop.systemd1.Unit"),
+            info=utils.load_interface_xml("org.freedesktop.systemd1.Unit"),
             bus_type=bus_type,
         )
 

--- a/ignis/services/upower/device.py
+++ b/ignis/services/upower/device.py
@@ -1,7 +1,7 @@
 from ignis.gobject import IgnisGObject, IgnisProperty, IgnisSignal
 from gi.repository import GLib  # type: ignore
 from ignis.dbus import DBusProxy
-from ignis.utils import Utils
+from ignis import utils
 from .constants import DEVICE_KIND, DeviceState
 
 
@@ -20,7 +20,7 @@ class UPowerDevice(IgnisGObject):
             name="org.freedesktop.UPower",
             object_path=object_path,
             interface_name="org.freedesktop.UPower.Device",
-            info=Utils.load_interface_xml("org.freedesktop.UPower.Device"),
+            info=utils.load_interface_xml("org.freedesktop.UPower.Device"),
             bus_type="system",
         )
         self._proxy.gproxy.connect("g-properties-changed", self.__sync)

--- a/ignis/services/upower/service.py
+++ b/ignis/services/upower/service.py
@@ -1,6 +1,6 @@
 from ignis.base_service import BaseService
 from ignis.dbus import DBusProxy
-from ignis.utils import Utils
+from ignis import utils
 from ignis.exceptions import UPowerNotRunningError
 from ignis.gobject import IgnisProperty, IgnisSignal
 from .device import UPowerDevice
@@ -22,7 +22,7 @@ class UPowerService(BaseService):
             name="org.freedesktop.UPower",
             object_path="/org/freedesktop/UPower",
             interface_name="org.freedesktop.UPower",
-            info=Utils.load_interface_xml("org.freedesktop.UPower"),
+            info=utils.load_interface_xml("org.freedesktop.UPower"),
             bus_type="system",
         )
 

--- a/ignis/services/wallpaper/service.py
+++ b/ignis/services/wallpaper/service.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from ignis.utils import Utils
+from ignis import utils
 from ignis.base_service import BaseService
 from ignis.options import options
 from .window import WallpaperLayerWindow
@@ -54,8 +54,8 @@ class WallpaperService(BaseService):
 
         self._windows = []
 
-        for monitor_id in range(Utils.get_n_monitors()):
-            gdkmonitor = Utils.get_monitor(monitor_id)
+        for monitor_id in range(utils.get_n_monitors()):
+            gdkmonitor = utils.get_monitor(monitor_id)
             if not gdkmonitor:
                 return
 

--- a/ignis/utils/__init__.py
+++ b/ignis/utils/__init__.py
@@ -19,8 +19,12 @@ from .version import (
     get_ignis_branch,
     get_ignis_commit_msg,
 )
+from ignis.deprecation import deprecated_class
 
 
+@deprecated_class(
+    message="""The "Utils" class is deprecated, please use "from ignis import utils" instead."""
+)
 class Utils:
     exec_sh = exec_sh
     exec_sh_async = exec_sh_async
@@ -56,3 +60,41 @@ class Utils:
     write_file = write_file
     write_file_async = write_file_async
     get_app_icon_name = get_app_icon_name
+
+
+__all__ = [
+    "AsyncCompletedProcess",
+    "DebounceTask",
+    "FileMonitor",
+    "Poll",
+    "ThreadTask",
+    "Timeout",
+    "crop_pixbuf",
+    "debounce",
+    "exec_sh",
+    "exec_sh_async",
+    "get_app_icon_name",
+    "get_current_dir",
+    "get_file_icon_name",
+    "get_ignis_branch",
+    "get_ignis_commit",
+    "get_ignis_commit_msg",
+    "get_ignis_version",
+    "get_monitor",
+    "get_monitors",
+    "get_n_monitors",
+    "get_paintable",
+    "listen_socket",
+    "load_interface_xml",
+    "pascal_to_snake",
+    "read_file",
+    "read_file_async",
+    "run_in_thread",
+    "sass_compile",
+    "scale_pixbuf",
+    "send_socket",
+    "snake_to_pascal",
+    "thread",
+    "write_file",
+    "write_file_async",
+]

--- a/ignis/utils/debounce.py
+++ b/ignis/utils/debounce.py
@@ -7,7 +7,7 @@ class DebounceTask:
     Delays function calls until a specified time elapses after the most recent call.
 
     .. hint::
-        See the decorator for this class :func:`~ignis.utils.Utils.debounce`.
+        See the decorator for this class :func:`~ignis.utils.utils.debounce`.
 
     Parameters:
         ms: The delay time in milliseconds.
@@ -33,7 +33,7 @@ def debounce(ms: int):
     """
     A decorator to delay function execution until a set time has passed since the last call.
 
-    This is a convenient wrapper for the :class:`~ignis.utils.Utils.DebounceTask` class.
+    This is a convenient wrapper for the :class:`~ignis.utils.utils.DebounceTask` class.
 
     Args:
         ms: The delay time in milliseconds.
@@ -42,9 +42,9 @@ def debounce(ms: int):
 
     .. code-block:: python
 
-        from ignis.utils import Utils
+        from ignis import utils
 
-        @Utils.debounce(500) # delay for 500 ms (0.5 s)
+        @utils.debounce(500) # delay for 500 ms (0.5 s)
         def some_func(x) -> None:
             print("called!")
 

--- a/ignis/utils/file.py
+++ b/ignis/utils/file.py
@@ -79,16 +79,16 @@ def read_file(
 
     .. code-block:: python
 
-        from ignis.utils import Utils
+        from ignis import utils
 
         # regular file
-        contents = Utils.read_file(path="/path/to/file", decode=True)
+        contents = utils.read_file(path="/path/to/file", decode=True)
         print(contents)
 
         # URI
-        Utils.read_file(uri="file:///path/to/file", decode=True)
+        utils.read_file(uri="file:///path/to/file", decode=True)
         # Web also supported
-        Utils.read_file(uri="https://SOME_SITE.org/example_content", decode=False)
+        utils.read_file(uri="https://SOME_SITE.org/example_content", decode=False)
     """
     gfile = _get_gfile(func_name="read_file()", path=path, uri=uri, gfile=gfile)
 
@@ -142,21 +142,21 @@ async def read_file_async(
     .. code-block:: python
 
         import asyncio
-        from ignis.utils import Utils
+        from ignis import utils
 
 
         async def some_func() -> None:
 
             # regular file
-            res1 = await Utils.read_file_async(path="/path/to/file", decode=True)
+            res1 = await utils.read_file_async(path="/path/to/file", decode=True)
             print("Contents 1: ", res1)
 
             # URI
-            res2 = await Utils.read_file_async(uri="file:///path/to/file", decode=True)
+            res2 = await utils.read_file_async(uri="file:///path/to/file", decode=True)
             print("Contents 2: ", res2)
 
             # Web also supported
-            res3 = await Utils.read_file_async(uri="https://SOME_SITE.org/example_content", decode=False)
+            res3 = await utils.read_file_async(uri="https://SOME_SITE.org/example_content", decode=False)
             print("Contents 3: ", res3)
 
 
@@ -197,14 +197,14 @@ def write_file(
     .. code-block:: python
 
         import asyncio
-        from ignis.utils import Utils
+        from ignis import utils
 
 
         async def some_write_func() -> None:
             # write string
-            await Utils.write_file(path="/path/to/file", string="some_string")
+            await utils.write_file(path="/path/to/file", string="some_string")
             # or bytes
-            await Utils.write_file(path="/path/to/file", bytes=b"some bytes")
+            await utils.write_file(path="/path/to/file", bytes=b"some bytes")
 
 
         asyncio.create_task(some_write_func())
@@ -243,15 +243,15 @@ async def write_file_async(
 
     .. code-block:: python
 
-        from ignis.utils import Utils
+        from ignis import utils
 
         def some_callback() -> None:
             print("Operation is complete")
 
         # write string
-        Utils.write_file_async(path="/path/to/file", string="some_string", callback=some_callback)
+        utils.write_file_async(path="/path/to/file", string="some_string", callback=some_callback)
         # or bytes
-        Utils.write_file_async(path="/path/to/file", bytes=b"some bytes", callback=some_callback)
+        utils.write_file_async(path="/path/to/file", bytes=b"some bytes", callback=some_callback)
     """
     gfile = _get_gfile(func_name="write_file_async()", path=path, uri=uri, gfile=gfile)
     contents = _get_contents(

--- a/ignis/utils/file_monitor.py
+++ b/ignis/utils/file_monitor.py
@@ -35,7 +35,7 @@ class FileMonitor(IgnisGObject):
 
     .. code-block::
 
-        Utils.FileMonitor(
+        utils.FileMonitor(
             path="path/to/something",
             recursive=False,
             callback=lambda path, event_type: print(path, event_type),

--- a/ignis/utils/poll.py
+++ b/ignis/utils/poll.py
@@ -19,10 +19,10 @@ class Poll(IgnisGObject):
 
     .. code-block:: python
 
-        from ignis.utils import Utils
+        from ignis import utils
 
         # print "Hello" every second
-        Utils.Poll(timeout=1_000, callback=lambda self: print("Hello"))
+        utils.Poll(timeout=1_000, callback=lambda self: print("Hello"))
     """
 
     def __init__(self, timeout: int, callback: Callable, *args):

--- a/ignis/utils/shell.py
+++ b/ignis/utils/shell.py
@@ -19,7 +19,7 @@ def exec_sh(command: str, **kwargs) -> subprocess.CompletedProcess:
 
 class AsyncCompletedProcess:
     """
-    Completed process object for :func:`~ignis.utils.Utils.exec_sh_async`.
+    Completed process object for :func:`~ignis.utils.utils.exec_sh_async`.
     """
 
     def __init__(self, stdout: str, stderr: str, returncode: int) -> None:

--- a/ignis/utils/socket.py
+++ b/ignis/utils/socket.py
@@ -60,7 +60,7 @@ def listen_socket(
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
             sock.connect("path/to/socket.sock")
 
-            for message in Utils.listen_socket(sock):
+            for message in utils.listen_socket(sock):
                 print(message)
     """
 

--- a/ignis/utils/timeout.py
+++ b/ignis/utils/timeout.py
@@ -15,9 +15,9 @@ class Timeout(IgnisGObject):
 
     .. code-block:: python
 
-        from ignis.utils import Utils
+        from ignis import utils
 
-        Utils.Timeout(ms=3000, target=lambda: print("Hello"))
+        utils.Timeout(ms=3000, target=lambda: print("Hello"))
     """
 
     def __init__(self, ms: int, target: Callable, *args):

--- a/ignis/widgets/arrow.py
+++ b/ignis/widgets/arrow.py
@@ -1,5 +1,5 @@
 from ignis.widgets.icon import Icon
-from ignis.utils import Utils
+from ignis import utils
 from ignis.gobject import IgnisProperty
 
 DIRECTION = {
@@ -90,7 +90,7 @@ class Arrow(Icon):
         interval = self.time // steps
 
         for i in range(steps):
-            Utils.Timeout(interval * i, self.__rotate, value)
+            utils.Timeout(interval * i, self.__rotate, value)
 
         self._rotated = value
 

--- a/ignis/widgets/file_chooser_button.py
+++ b/ignis/widgets/file_chooser_button.py
@@ -6,7 +6,7 @@ from ignis.widgets.label import Label
 from ignis.widgets.box import Box
 from ignis.widgets.icon import Icon
 from ignis.widgets.file_dialog import FileDialog
-from ignis.utils import Utils
+from ignis import utils
 from ignis.gobject import IgnisProperty
 
 
@@ -89,7 +89,7 @@ class FileChooserButton(Gtk.Button, BaseWidget):
     def __sync(self, path: str) -> None:
         self.label.label = os.path.basename(path)
         try:
-            self.__file_icon.icon_name = Utils.get_file_icon_name(path, symbolic=True)
+            self.__file_icon.icon_name = utils.get_file_icon_name(path, symbolic=True)
             self.__file_icon.visible = True
         except FileNotFoundError:
             pass

--- a/ignis/widgets/icon.py
+++ b/ignis/widgets/icon.py
@@ -1,7 +1,7 @@
 import os
 from ignis.base_widget import BaseWidget
 from gi.repository import Gtk, GdkPixbuf, Gdk  # type: ignore
-from ignis.utils import Utils
+from ignis import utils
 from ignis.gobject import IgnisProperty
 
 
@@ -60,7 +60,7 @@ class Icon(Gtk.Image, BaseWidget):
             return
 
         if not self.pixel_size <= 0:
-            pixbuf = Utils.scale_pixbuf(pixbuf, self.pixel_size, self.pixel_size)
+            pixbuf = utils.scale_pixbuf(pixbuf, self.pixel_size, self.pixel_size)
 
         paintable = Gdk.Texture.new_for_pixbuf(pixbuf)
         self.set_from_paintable(paintable)

--- a/ignis/widgets/picture.py
+++ b/ignis/widgets/picture.py
@@ -1,7 +1,7 @@
 import os
 from ignis.base_widget import BaseWidget
 from gi.repository import Gtk, GdkPixbuf, Gdk  # type: ignore
-from ignis.utils import Utils
+from ignis import utils
 from ignis.gobject import IgnisProperty
 
 
@@ -137,7 +137,7 @@ class Picture(Gtk.Picture, BaseWidget):
         if size <= 0:
             size = 16
 
-        paintable = Utils.get_paintable(self, icon_name, size)
+        paintable = utils.get_paintable(self, icon_name, size)
 
         if not paintable:
             return
@@ -165,6 +165,6 @@ class Picture(Gtk.Picture, BaseWidget):
             return pixbuf
 
         if self.content_fit == "cover":
-            pixbuf = Utils.crop_pixbuf(pixbuf, width, height)
+            pixbuf = utils.crop_pixbuf(pixbuf, width, height)
 
-        return Utils.scale_pixbuf(pixbuf, width, height)
+        return utils.scale_pixbuf(pixbuf, width, height)

--- a/ignis/widgets/revealer_window.py
+++ b/ignis/widgets/revealer_window.py
@@ -1,6 +1,6 @@
 from .window import Window
 from .revealer import Revealer
-from ignis.utils import Utils
+from ignis import utils
 from typing import Any
 from ignis.gobject import IgnisProperty
 
@@ -55,7 +55,7 @@ class RevealerWindow(Window):
             if value:
                 super().set_property(prop_name, value)
             else:
-                Utils.Timeout(
+                utils.Timeout(
                     ms=self._revealer.transition_duration,
                     target=lambda x=super(): x.set_property(prop_name, value),
                 )

--- a/ignis/widgets/window.py
+++ b/ignis/widgets/window.py
@@ -1,7 +1,7 @@
 import cairo
 from gi.repository import Gtk  # type: ignore
 from ignis.base_widget import BaseWidget
-from ignis.utils import Utils
+from ignis import utils
 from gi.repository import Gtk4LayerShell as GtkLayerShell  # type: ignore
 from ignis.exceptions import (
     MonitorNotFoundError,
@@ -309,7 +309,7 @@ class Window(Gtk.Window, BaseWidget):
         if value is None:
             return
 
-        gdkmonitor = Utils.get_monitor(value)
+        gdkmonitor = utils.get_monitor(value)
         if gdkmonitor is None:
             raise MonitorNotFoundError(value)
 


### PR DESCRIPTION
The same as #299, but for utils.

## Breaking Changes

The `Utils` class is now deprecated (though not removed), and you have to use `from ignis import utils` instead.

To ease the transition, you can use search & replace in your code editor:

> [!CAUTION]
> Make sure you made a backup of your configuration!

1. Replace: `from ignis.utils import Utils` -> `from ignis import utils`
2. Replace: `Utils.` -> `utils.`  (double-check that you're replacing, something extra may be matched)

Alternatively, if you still want to use `Utils` name, you can alias the import:

```python
from ignis import utils as Utils
```

...or:

```python
import ignis.utils as Utils
```

> [!NOTE]
> `from ignis import utils` is preferred and will be used in the documentation and examples


## TODO
- [x] Write a bash or python script to make the transition automatic
- [x] Check that I replaced everything correctly
- [x] Another check that I did everything correctly
- [x] Check for typos
- [x] Check for typos 2
- [x] I am sure
- [x] I am **really** sure