### PR TITLE
fix!: create temp directory only when necessary

### DIFF
--- a/ignis/__init__.py
+++ b/ignis/__init__.py
@@ -32,19 +32,49 @@ is_sphinx_build: bool = "sphinx" in sys.modules
 is_editable_install: bool = _get_is_editable_install()
 
 #: The random temporary directory for this Ignis instance.
-TEMP_DIR = tempfile.mkdtemp(prefix="ignis-")
+#:
+#: .. deprecated:: 0.6
+#:    Use :func:`get_temp_dir` instead.
+TEMP_DIR = "/tmp/ignis-deprecated-temp"
 
-#: The cache directory. Equals ``$XDG_CACHE_HOME/ignis`` by default, or :obj:`TEMP_DIR` during the Sphinx doc build.
-CACHE_DIR = f"{GLib.get_user_cache_dir()}/ignis" if not is_sphinx_build else TEMP_DIR
+#: The cache directory, equals ``$XDG_CACHE_HOME/ignis``.
+CACHE_DIR = (
+    f"{GLib.get_user_cache_dir()}/ignis"
+    if not is_sphinx_build
+    else "$XDG_CACHE_HOME/ignis"
+)
 
-#: The data directory. Equals ``$XDG_DATA_HOME/ignis`` by default, or :obj:`TEMP_DIR` during the Sphinx doc build.
-DATA_DIR = f"{GLib.get_user_data_dir()}/ignis" if not is_sphinx_build else TEMP_DIR
+#: The data directory, equals ``$XDG_DATA_HOME/ignis``.
+DATA_DIR = (
+    f"{GLib.get_user_data_dir()}/ignis"
+    if not is_sphinx_build
+    else "$XDG_DATA_HOME/ignis"
+)
 
 #: Whether libgirepository-2.0 is being used (``True`` for PyGObject 3.51.0 and higher).
 #: Always equals ``False`` during the Sphinx doc build.
 is_girepository_2_0: bool = (
     gi.version_info >= (3, 51, 0) if not is_sphinx_build else False  # type: ignore
 )
+
+global _temp_dir
+_temp_dir: str | None = None
+
+
+def get_temp_dir() -> str:
+    """
+    Get the temporary directory for this Ignis instance.
+    Create if it doesn't exist, otherwise return the existing one.
+
+    Returns:
+        The temporary directory for this Ignis instance.
+    """
+    global _temp_dir
+
+    if not _temp_dir:
+        _temp_dir = tempfile.mkdtemp(prefix="ignis-")
+
+    return _temp_dir
 
 
 def _prepend_to_repo(path: str) -> None:

--- a/ignis/utils/sass.py
+++ b/ignis/utils/sass.py
@@ -2,9 +2,8 @@ import shutil
 import subprocess
 from typing import Literal
 from ignis.exceptions import SassCompilationError, SassNotFoundError
-from ignis import TEMP_DIR
+from ignis import get_temp_dir
 
-COMPILED_CSS = f"{TEMP_DIR}/compiled.css"
 
 # resolve Sass compiler paths and pick a default one
 # "sass" (dart-sass) is the default,
@@ -17,12 +16,14 @@ for cmd in ("sass", "grass"):
 
 
 def compile_file(path: str, compiler_path: str) -> str:
-    result = subprocess.run([compiler_path, path, COMPILED_CSS], capture_output=True)
+    compiled_css = f"{get_temp_dir()}/compiled.css"
+
+    result = subprocess.run([compiler_path, path, compiled_css], capture_output=True)
 
     if result.returncode != 0:
         raise SassCompilationError(result.stderr.decode())
 
-    with open(COMPILED_CSS) as file:
+    with open(compiled_css) as file:
         return file.read()
 
 


### PR DESCRIPTION
## Breaking changes

`ignis.TEMP_DIR` is deprecated, use `ignis.get_temp_dir()` instead.