### PR TITLE
refactor: extract singleton logic into separate classes

### DIFF
--- a/docs/api/gobject.rst
+++ b/docs/api/gobject.rst
@@ -4,6 +4,9 @@ GObject
 .. autoclass:: ignis.gobject.IgnisGObject
     :members:
 
+.. autoclass:: ignis.gobject.IgnisGObjectSingleton
+    :members:
+
 .. autoclass:: ignis.gobject.Binding
     :members:
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -8,6 +8,7 @@ This reference manual details functions, modules, and objects included in Ignis,
 
    toplevel
    app
+   singleton
    gobject
    variable
    client

--- a/docs/api/singleton.rst
+++ b/docs/api/singleton.rst
@@ -1,0 +1,5 @@
+Singleton
+=========
+
+.. autoclass:: ignis.singleton.IgnisSingleton
+    :members:

--- a/ignis/base_service.py
+++ b/ignis/base_service.py
@@ -1,26 +1,11 @@
-from ignis.gobject import IgnisGObject
-from typing import TypeVar
-
-T = TypeVar("T", bound="BaseService")
+from ignis.gobject import IgnisGObjectSingleton
 
 
-class BaseService(IgnisGObject):
+# FIXME: Probably it should be deprecated due to its lack of utility.
+# But I will leave it as is for now in case I find a meaningful use for it.
+class BaseService(IgnisGObjectSingleton):
     """
-    Bases: :class:`~ignis.gobject.IgnisGObject`.
+    Bases: :class:`~ignis.gobject.IgnisGObjectSingleton`.
 
     The base class for all services.
     """
-
-    _instance: T | None = None  # type: ignore
-
-    def __init__(self) -> None:
-        super().__init__()
-
-    @classmethod
-    def get_default(cls: type[T]) -> T:
-        """
-        Returns the default Service object for this process, creating it if necessary.
-        """
-        if cls._instance is None:
-            cls._instance = cls()
-        return cls._instance

--- a/ignis/gobject.py
+++ b/ignis/gobject.py
@@ -3,6 +3,7 @@ from gi.repository import GObject, GLib  # type: ignore
 from typing import Any, Literal, get_args, get_origin
 from collections.abc import Callable
 from ignis import is_sphinx_build, is_girepository_2_0
+from ignis.singleton import IgnisSingleton
 
 
 class Binding(GObject.Object):
@@ -189,6 +190,14 @@ class IgnisGObject(GObject.Object):
                 return lambda: self.get_property(property_name)
 
         return super().__getattribute__(name)
+
+
+class IgnisGObjectSingleton(IgnisGObject, IgnisSingleton):
+    """
+    Bases: :class:`IgnisGObject`, :class:`~ignis.singleton.IgnisSingleton`.
+
+    The :class:`IgnisGObject` singleton class.
+    """
 
 
 if is_sphinx_build:

--- a/ignis/singleton.py
+++ b/ignis/singleton.py
@@ -1,0 +1,20 @@
+from typing import TypeVar
+
+_SingletonT = TypeVar("_SingletonT", bound="IgnisSingleton")
+
+
+class IgnisSingleton:
+    """
+    The singleton class.
+    """
+
+    _instance: _SingletonT | None = None  # type: ignore
+
+    @classmethod
+    def get_default(cls: type[_SingletonT]) -> _SingletonT:
+        """
+        Returns the default instance for this process, creating it if necessary.
+        """
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance


### PR DESCRIPTION
Adds separate ``IgnisSingleton`` and ``IgnisGObjectSingleton`` classes. Idk what to do with `BaseService`, let's leave it as is for now.
It's just a small step for #137...