### PR TITLE
refactor!: extract window management into separate `WindowManager` class

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -8,6 +8,7 @@ This reference manual details functions, modules, and objects included in Ignis,
 
    toplevel
    app
+   window_manager
    singleton
    gobject
    variable

--- a/docs/api/window_manager.rst
+++ b/docs/api/window_manager.rst
@@ -1,0 +1,5 @@
+WindowManager
+=============
+
+.. autoclass:: ignis.window_manager.WindowManager
+    :members:

--- a/docs/examples/code_snippets.rst
+++ b/docs/examples/code_snippets.rst
@@ -18,7 +18,7 @@ A common use case is to close a window.
                 vexpand=True,
                 hexpand=True,
                 can_focus=False,
-                on_click=lambda x: CALLBACK, # e.g., app.close_window("my-window")
+                on_click=lambda x: CALLBACK, # e.g., window_manager.close_window("my-window")
             ),
             overlays=[ACTUAL_CONTENT],
         ),

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -33,6 +33,9 @@ GTK_STYLE_PRIORITIES: dict[StylePriority, int] = {
 }
 
 window_manager = WindowManager.get_default()
+_window_deprecated_func = deprecated_func(
+    "IgnisApp.{name}() is deprecated, use WindowManager.{name}() instead."
+)
 
 
 def raise_css_parsing_error(
@@ -445,9 +448,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
     def __happy_new_year(self) -> None:
         logger.success("Happy New Year!")
 
-    @deprecated_func(
-        "{name} is deprecated, use ignis.window_manager.WindowManager.get_window() instead."
-    )
+    @_window_deprecated_func
     def get_window(self, window_name: str) -> Gtk.Window:
         """
         .. deprecated:: 0.6
@@ -455,9 +456,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         """
         return window_manager.get_window(window_name)
 
-    @deprecated_func(
-        "{name} is deprecated, use ignis.window_manager.WindowManager.open_window() instead."
-    )
+    @_window_deprecated_func
     def open_window(self, window_name: str) -> None:
         """
         .. deprecated:: 0.6
@@ -465,9 +464,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         """
         window_manager.open_window(window_name)
 
-    @deprecated_func(
-        "{name} is deprecated, use ignis.window_manager.WindowManager.close_window() instead."
-    )
+    @_window_deprecated_func
     def close_window(self, window_name: str) -> None:
         """
         .. deprecated:: 0.6
@@ -475,9 +472,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         """
         window_manager.close_window(window_name)
 
-    @deprecated_func(
-        "{name} is deprecated, use ignis.window_manager.WindowManager.toggle_window() instead."
-    )
+    @_window_deprecated_func
     def toggle_window(self, window_name: str) -> None:
         """
         .. deprecated:: 0.6
@@ -485,9 +480,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         """
         window_manager.toggle_window(window_name)
 
-    @deprecated_func(
-        "{name} is deprecated, use ignis.window_manager.WindowManager.add_window() instead."
-    )
+    @_window_deprecated_func
     def add_window(self, window_name: str, window: Gtk.Window) -> None:  # type: ignore
         """
         .. deprecated:: 0.6
@@ -495,9 +488,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         """
         window_manager.add_window(window_name, window)
 
-    @deprecated_func(
-        "{name} is deprecated, use ignis.window_manager.WindowManager.remove_window() instead."
-    )
+    @_window_deprecated_func
     def remove_window(self, window_name: str) -> None:  # type: ignore
         """
         .. deprecated:: 0.6

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -20,7 +20,7 @@ from ignis.exceptions import (
 )
 from ignis.log_utils import configure_logger
 from ignis.window_manager import WindowManager
-from ignis.deprecation import deprecated_func
+from ignis.deprecation import deprecated_func, deprecation_warning
 
 StylePriority = Literal["application", "fallback", "settings", "theme", "user"]
 
@@ -157,14 +157,15 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         """
         return self._is_ready
 
-    @deprecated_func(
-        "{name} property is deprecated, use ignis.window_manager.WindowManager.windows property instead."
-    )
     @IgnisProperty
     def windows(self) -> list[Gtk.Window]:
         """
-        A list of windows added to this application.
+        .. deprecated:: 0.6
+            Use :attr:`~ignis.window_manager.WindowManager.windows` instead.
         """
+        deprecation_warning(
+            "IgnisApp.windows is deprecated, use WindowManager.windows instead."
+        )
         return window_manager.windows
 
     @IgnisProperty

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -12,7 +12,6 @@ from loguru import logger
 from gi.repository import Gtk, Gdk, Gio, GLib  # type: ignore
 from ignis.gobject import IgnisGObject, IgnisProperty, IgnisSignal
 from ignis.exceptions import (
-    WindowAddedError,
     WindowNotFoundError,
     DisplayNotFoundError,
     StylePathNotFoundError,
@@ -20,6 +19,8 @@ from ignis.exceptions import (
     CssParsingError,
 )
 from ignis.log_utils import configure_logger
+from ignis.window_manager import WindowManager
+from ignis.deprecation import deprecated_func
 
 StylePriority = Literal["application", "fallback", "settings", "theme", "user"]
 
@@ -30,6 +31,8 @@ GTK_STYLE_PRIORITIES: dict[StylePriority, int] = {
     "theme": Gtk.STYLE_PROVIDER_PRIORITY_THEME,
     "user": Gtk.STYLE_PROVIDER_PRIORITY_USER,
 }
+
+window_manager = WindowManager.get_default()
 
 
 def raise_css_parsing_error(
@@ -98,7 +101,6 @@ class IgnisApp(Gtk.Application, IgnisGObject):
 
         self._config_path: str | None = None
         self._css_providers: dict[str, _CssProviderInfo] = {}
-        self._windows: dict[str, Gtk.Window] = {}
         self._autoreload_config: bool = True
         self._autoreload_css: bool = True
         self._reload_on_monitors_change: bool = True
@@ -152,12 +154,13 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         """
         return self._is_ready
 
+    @deprecated_func("{name} property is deprecated, use ignis.window_manager.WindowManager.windows property instead.")
     @IgnisProperty
     def windows(self) -> list[Gtk.Window]:
         """
         A list of windows added to this application.
         """
-        return list(self._windows.values())
+        return window_manager.windows
 
     @IgnisProperty
     def autoreload_config(self) -> bool:
@@ -440,92 +443,65 @@ class IgnisApp(Gtk.Application, IgnisGObject):
     def __happy_new_year(self) -> None:
         logger.success("Happy New Year!")
 
+    @deprecated_func(
+        "{name} is deprecated, use ignis.window_manager.WindowManager.get_window() instead."
+    )
     def get_window(self, window_name: str) -> Gtk.Window:
         """
-        Get a window by name.
-
-        Args:
-            window_name: The window's namespace.
-
-        Returns:
-            The window object.
-
-        Raises:
-            WindowNotFoundError: If a window with the given namespace does not exist.
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.get_window` instead.
         """
-        window = self._windows.get(window_name, None)
-        if window:
-            return window
-        else:
-            raise WindowNotFoundError(window_name)
+        return window_manager.get_window(window_name)
 
+    @deprecated_func(
+        "{name} is deprecated, use ignis.window_manager.WindowManager.open_window() instead."
+    )
     def open_window(self, window_name: str) -> None:
         """
-        Open (show) a window by its name.
-
-        Args:
-            window_name: The window's namespace.
-        Raises:
-            WindowNotFoundError: If a window with the given namespace does not exist.
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.open_window` instead.
         """
-        window = self.get_window(window_name)
-        window.set_visible(True)
+        window_manager.open_window(window_name)
 
+    @deprecated_func(
+        "{name} is deprecated, use ignis.window_manager.WindowManager.close_window() instead."
+    )
     def close_window(self, window_name: str) -> None:
         """
-        Close (hide) a window by its name.
-
-        Args:
-            window_name: The window's namespace.
-        Raises:
-            WindowNotFoundError: If a window with the given namespace does not exist.
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.close_window` instead.
         """
-        window = self.get_window(window_name)
-        window.set_visible(False)
+        window_manager.close_window(window_name)
 
+    @deprecated_func(
+        "{name} is deprecated, use ignis.window_manager.WindowManager.toggle_window() instead."
+    )
     def toggle_window(self, window_name: str) -> None:
         """
-        Toggle (change visibility to opposite state) a window by its name.
-
-        Args:
-            window_name: The window's namespace.
-        Raises:
-            WindowNotFoundError: If a window with the given namespace does not exist.
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.close_window` instead.
         """
-        window = self.get_window(window_name)
-        window.set_visible(not window.get_visible())
+        window_manager.toggle_window(window_name)
 
+    @deprecated_func(
+        "{name} is deprecated, use ignis.window_manager.WindowManager.add_window() instead."
+    )
     def add_window(self, window_name: str, window: Gtk.Window) -> None:  # type: ignore
         """
-        Add a window.
-        You typically shouldn't use this method, as windows are added to the app automatically.
-
-        Args:
-            window_name: The window's namespace.
-            window: The window instance.
-
-        Raises:
-            WindowAddedError: If a window with the given namespace already exists.
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.add_window` instead.
         """
-        if window_name in self._windows:
-            raise WindowAddedError(window_name)
+        window_manager.add_window(window_name, window)
 
-        self._windows[window_name] = window
-
+    @deprecated_func(
+        "{name} is deprecated, use ignis.window_manager.WindowManager.remove_window() instead."
+    )
     def remove_window(self, window_name: str) -> None:  # type: ignore
         """
-        Remove a window by its name.
-        The window will be removed from the application.
-
-        Args:
-            window_name: The window's namespace.
-
-        Raises:
-            WindowNotFoundError: If a window with the given namespace does not exist.
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.remove_window` instead.
         """
-        window = self._windows.pop(window_name, None)
-        if not window:
-            raise WindowNotFoundError(window_name)
+        window_manager.remove_window(window_name)
 
     def reload(self) -> None:
         """
@@ -561,9 +537,9 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         """
         Gtk.Window.set_interactive_debugging(True)
 
-    def __call_window_method(self, _type: str, window_name: str) -> GLib.Variant:
+    def __call_window_method(self, type_: str, window_name: str) -> GLib.Variant:
         try:
-            getattr(self, f"{_type}_window")(window_name)
+            getattr(window_manager, f"{type_}_window")(window_name)
             return GLib.Variant("(b)", (True,))
         except WindowNotFoundError:
             return GLib.Variant("(b)", (False,))

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -452,54 +452,6 @@ class IgnisApp(Gtk.Application, IgnisGObject):
     def __happy_new_year(self) -> None:
         logger.success("Happy New Year!")
 
-    def get_window(self, window_name: str) -> Gtk.Window:
-        """
-        .. deprecated:: 0.6
-            Use :func:`~ignis.window_manager.WindowManager.get_window` instead.
-        """
-        _window_deprecated_func("get_window")
-        return window_manager.get_window(window_name)
-
-    def open_window(self, window_name: str) -> None:
-        """
-        .. deprecated:: 0.6
-            Use :func:`~ignis.window_manager.WindowManager.open_window` instead.
-        """
-        _window_deprecated_func("open_window")
-        window_manager.open_window(window_name)
-
-    def close_window(self, window_name: str) -> None:
-        """
-        .. deprecated:: 0.6
-            Use :func:`~ignis.window_manager.WindowManager.close_window` instead.
-        """
-        _window_deprecated_func("close_window")
-        window_manager.close_window(window_name)
-
-    def toggle_window(self, window_name: str) -> None:
-        """
-        .. deprecated:: 0.6
-            Use :func:`~ignis.window_manager.WindowManager.close_window` instead.
-        """
-        _window_deprecated_func("toggle_window")
-        window_manager.toggle_window(window_name)
-
-    def add_window(self, window_name: str, window: Gtk.Window) -> None:  # type: ignore
-        """
-        .. deprecated:: 0.6
-            Use :func:`~ignis.window_manager.WindowManager.add_window` instead.
-        """
-        _window_deprecated_func("add_window")
-        window_manager.add_window(window_name, window)
-
-    def remove_window(self, window_name: str) -> None:  # type: ignore
-        """
-        .. deprecated:: 0.6
-            Use :func:`~ignis.window_manager.WindowManager.remove_window` instead.
-        """
-        _window_deprecated_func("remove_window")
-        window_manager.remove_window(window_name)
-
     def reload(self) -> None:
         """
         Reload Ignis.
@@ -572,6 +524,57 @@ class IgnisApp(Gtk.Application, IgnisGObject):
 
     def __Quit(self, invocation) -> None:
         self.quit()
+
+    # =========================== DEPRECATED ZONE START ===========================
+    def get_window(self, window_name: str) -> Gtk.Window:
+        """
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.get_window` instead.
+        """
+        _window_deprecated_func("get_window")
+        return window_manager.get_window(window_name)
+
+    def open_window(self, window_name: str) -> None:
+        """
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.open_window` instead.
+        """
+        _window_deprecated_func("open_window")
+        window_manager.open_window(window_name)
+
+    def close_window(self, window_name: str) -> None:
+        """
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.close_window` instead.
+        """
+        _window_deprecated_func("close_window")
+        window_manager.close_window(window_name)
+
+    def toggle_window(self, window_name: str) -> None:
+        """
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.toggle_window` instead.
+        """
+        _window_deprecated_func("toggle_window")
+        window_manager.toggle_window(window_name)
+
+    def add_window(self, window_name: str, window: Gtk.Window) -> None:  # type: ignore
+        """
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.add_window` instead.
+        """
+        _window_deprecated_func("add_window")
+        window_manager.add_window(window_name, window)
+
+    def remove_window(self, window_name: str) -> None:  # type: ignore
+        """
+        .. deprecated:: 0.6
+            Use :func:`~ignis.window_manager.WindowManager.remove_window` instead.
+        """
+        _window_deprecated_func("remove_window")
+        window_manager.remove_window(window_name)
+
+    # ============================ DEPRECATED ZONE END ============================
 
 
 def run_app(config_path: str, debug: bool) -> None:

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -154,7 +154,9 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         """
         return self._is_ready
 
-    @deprecated_func("{name} property is deprecated, use ignis.window_manager.WindowManager.windows property instead.")
+    @deprecated_func(
+        "{name} property is deprecated, use ignis.window_manager.WindowManager.windows property instead."
+    )
     @IgnisProperty
     def windows(self) -> list[Gtk.Window]:
         """

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -20,7 +20,7 @@ from ignis.exceptions import (
 )
 from ignis.log_utils import configure_logger
 from ignis.window_manager import WindowManager
-from ignis.deprecation import deprecated_func, deprecation_warning
+from ignis.deprecation import deprecation_warning
 
 StylePriority = Literal["application", "fallback", "settings", "theme", "user"]
 
@@ -33,9 +33,12 @@ GTK_STYLE_PRIORITIES: dict[StylePriority, int] = {
 }
 
 window_manager = WindowManager.get_default()
-_window_deprecated_func = deprecated_func(
-    "IgnisApp.{name}() is deprecated, use WindowManager.{name}() instead."
-)
+
+
+def _window_deprecated_func(name: str):
+    deprecation_warning(
+        f"IgnisApp.{name}() is deprecated, use WindowManager.{name}() instead."
+    )
 
 
 def raise_css_parsing_error(
@@ -449,52 +452,52 @@ class IgnisApp(Gtk.Application, IgnisGObject):
     def __happy_new_year(self) -> None:
         logger.success("Happy New Year!")
 
-    @_window_deprecated_func
     def get_window(self, window_name: str) -> Gtk.Window:
         """
         .. deprecated:: 0.6
             Use :func:`~ignis.window_manager.WindowManager.get_window` instead.
         """
+        _window_deprecated_func("get_window")
         return window_manager.get_window(window_name)
 
-    @_window_deprecated_func
     def open_window(self, window_name: str) -> None:
         """
         .. deprecated:: 0.6
             Use :func:`~ignis.window_manager.WindowManager.open_window` instead.
         """
+        _window_deprecated_func("open_window")
         window_manager.open_window(window_name)
 
-    @_window_deprecated_func
     def close_window(self, window_name: str) -> None:
         """
         .. deprecated:: 0.6
             Use :func:`~ignis.window_manager.WindowManager.close_window` instead.
         """
+        _window_deprecated_func("close_window")
         window_manager.close_window(window_name)
 
-    @_window_deprecated_func
     def toggle_window(self, window_name: str) -> None:
         """
         .. deprecated:: 0.6
             Use :func:`~ignis.window_manager.WindowManager.close_window` instead.
         """
+        _window_deprecated_func("toggle_window")
         window_manager.toggle_window(window_name)
 
-    @_window_deprecated_func
     def add_window(self, window_name: str, window: Gtk.Window) -> None:  # type: ignore
         """
         .. deprecated:: 0.6
             Use :func:`~ignis.window_manager.WindowManager.add_window` instead.
         """
+        _window_deprecated_func("add_window")
         window_manager.add_window(window_name, window)
 
-    @_window_deprecated_func
     def remove_window(self, window_name: str) -> None:  # type: ignore
         """
         .. deprecated:: 0.6
             Use :func:`~ignis.window_manager.WindowManager.remove_window` instead.
         """
+        _window_deprecated_func("remove_window")
         window_manager.remove_window(window_name)
 
     def reload(self) -> None:

--- a/ignis/client.py
+++ b/ignis/client.py
@@ -57,19 +57,19 @@ class IgnisClient:
 
     def open_window(self, window_name: str) -> None:
         """
-        Same as :func:`~ignis.app.IgnisApp.open_window`.
+        Same as :func:`~ignis.window_manager.WindowManager.open_window`.
         """
         self.__call_window_method("OpenWindow", window_name)
 
     def close_window(self, window_name: str) -> None:
         """
-        Same as :func:`~ignis.app.IgnisApp.close_window`.
+        Same as :func:`~ignis.window_manager.WindowManager.close_window`.
         """
         self.__call_window_method("CloseWindow", window_name)
 
     def toggle_window(self, window_name: str) -> None:
         """
-        Same as :func:`~ignis.app.IgnisApp.toggle_window`.
+        Same as :func:`~ignis.window_manager.WindowManager.toggle_window`.
         """
         self.__call_window_method("ToggleWindow", window_name)
 

--- a/ignis/services/network/access_point.py
+++ b/ignis/services/network/access_point.py
@@ -9,6 +9,7 @@ from .constants import WIFI_ICON_TEMPLATE
 
 window_manager = WindowManager.get_default()
 
+
 class WifiAccessPoint(IgnisGObject):
     """
     A Wi-Fi access point (Wi-Fi network).

--- a/ignis/services/network/access_point.py
+++ b/ignis/services/network/access_point.py
@@ -1,14 +1,13 @@
 from gi.repository import GLib  # type: ignore
 from ignis.gobject import IgnisGObject, IgnisProperty, IgnisSignal
 from typing import Literal
-from ignis.app import IgnisApp
+from ignis.window_manager import WindowManager
 from .util import filter_connections
 from ._imports import NM
 from .wifi_connect_dialog import WifiConnectDialog
 from .constants import WIFI_ICON_TEMPLATE
 
-app = IgnisApp.get_default()
-
+window_manager = WindowManager.get_default()
 
 class WifiAccessPoint(IgnisGObject):
     """
@@ -366,7 +365,7 @@ class WifiAccessPoint(IgnisGObject):
             self._connect_dialog.destroy()
 
     def __invoke_wifi_dialog(self) -> None:
-        if self._connect_dialog not in app.windows:
+        if self._connect_dialog not in window_manager.windows:
             self._connect_dialog = WifiConnectDialog(
                 self, self.__connect_to_graphical_callback
             )

--- a/ignis/services/wallpaper/window.py
+++ b/ignis/services/wallpaper/window.py
@@ -2,9 +2,6 @@ from ignis.widgets.picture import Picture
 from gi.repository import Gtk, Gdk  # type: ignore
 from gi.repository import Gtk4LayerShell as GtkLayerShell  # type: ignore
 from ignis.exceptions import LayerShellNotSupportedError
-from ignis.app import IgnisApp
-
-app = IgnisApp.get_default()
 
 
 class WallpaperLayerWindow(Gtk.Window):
@@ -14,7 +11,7 @@ class WallpaperLayerWindow(Gtk.Window):
         if not GtkLayerShell.is_supported():
             raise LayerShellNotSupportedError()
 
-        Gtk.Window.__init__(self, application=app)
+        Gtk.Window.__init__(self)
         GtkLayerShell.init_for_window(self)
 
         for anchor in ["LEFT", "RIGHT", "TOP", "BOTTOM"]:

--- a/ignis/services/wallpaper/window.py
+++ b/ignis/services/wallpaper/window.py
@@ -2,6 +2,7 @@ from ignis.widgets.picture import Picture
 from gi.repository import Gtk, Gdk  # type: ignore
 from gi.repository import Gtk4LayerShell as GtkLayerShell  # type: ignore
 from ignis.exceptions import LayerShellNotSupportedError
+from ignis.app import IgnisApp
 
 
 class WallpaperLayerWindow(Gtk.Window):
@@ -11,7 +12,9 @@ class WallpaperLayerWindow(Gtk.Window):
         if not GtkLayerShell.is_supported():
             raise LayerShellNotSupportedError()
 
-        Gtk.Window.__init__(self)
+        app = IgnisApp.get_default()
+
+        Gtk.Window.__init__(self, application=app)
         GtkLayerShell.init_for_window(self)
 
         for anchor in ["LEFT", "RIGHT", "TOP", "BOTTOM"]:

--- a/ignis/widgets/regular_window.py
+++ b/ignis/widgets/regular_window.py
@@ -1,11 +1,10 @@
 from gi.repository import Gtk  # type: ignore
 from ignis.base_widget import BaseWidget
-from ignis.app import IgnisApp
+from ignis.window_manager import WindowManager
 from ignis.exceptions import WindowNotFoundError
 from ignis.gobject import IgnisProperty
 
-app = IgnisApp.get_default()
-
+window_manager = WindowManager.get_default()
 
 class RegularWindow(Gtk.Window, BaseWidget):
     """
@@ -36,7 +35,7 @@ class RegularWindow(Gtk.Window, BaseWidget):
 
         self._namespace = namespace
 
-        app.add_window(namespace, self)
+        window_manager.add_window(namespace, self)
 
         self.connect("close-request", self.__on_close_request)
 
@@ -50,7 +49,7 @@ class RegularWindow(Gtk.Window, BaseWidget):
 
     def __remove(self, *args) -> None:
         try:
-            app.remove_window(self.namespace)
+            window_manager.remove_window(self.namespace)
         except WindowNotFoundError:
             pass
 

--- a/ignis/widgets/regular_window.py
+++ b/ignis/widgets/regular_window.py
@@ -6,6 +6,7 @@ from ignis.gobject import IgnisProperty
 
 window_manager = WindowManager.get_default()
 
+
 class RegularWindow(Gtk.Window, BaseWidget):
     """
     Bases: :class:`Gtk.Window`

--- a/ignis/widgets/window.py
+++ b/ignis/widgets/window.py
@@ -10,9 +10,9 @@ from ignis.exceptions import (
 )
 from ignis.gobject import IgnisProperty, IgnisSignal
 from ignis.window_manager import WindowManager
+from ignis.app import IgnisApp
 
 window_manager = WindowManager.get_default()
-
 LAYER = {
     "background": GtkLayerShell.Layer.BACKGROUND,
     "bottom": GtkLayerShell.Layer.BOTTOM,
@@ -111,7 +111,9 @@ class Window(Gtk.Window, BaseWidget):
         if not GtkLayerShell.is_supported():
             raise LayerShellNotSupportedError()
 
-        Gtk.Window.__init__(self)
+        app = IgnisApp.get_default()
+
+        Gtk.Window.__init__(self, application=app)
         GtkLayerShell.init_for_window(self)
 
         self._anchor = None

--- a/ignis/widgets/window.py
+++ b/ignis/widgets/window.py
@@ -8,10 +8,10 @@ from ignis.exceptions import (
     LayerShellNotSupportedError,
     WindowNotFoundError,
 )
-from ignis.app import IgnisApp
 from ignis.gobject import IgnisProperty, IgnisSignal
+from ignis.window_manager import WindowManager
 
-app = IgnisApp.get_default()
+window_manager = WindowManager.get_default()
 
 LAYER = {
     "background": GtkLayerShell.Layer.BACKGROUND,
@@ -111,7 +111,7 @@ class Window(Gtk.Window, BaseWidget):
         if not GtkLayerShell.is_supported():
             raise LayerShellNotSupportedError()
 
-        Gtk.Window.__init__(self, application=app)  # type: ignore
+        Gtk.Window.__init__(self)
         GtkLayerShell.init_for_window(self)
 
         self._anchor = None
@@ -145,7 +145,7 @@ class Window(Gtk.Window, BaseWidget):
 
         GtkLayerShell.set_namespace(self, name_space=namespace)
 
-        app.add_window(namespace, self)
+        window_manager.add_window(namespace, self)
 
         key_controller = Gtk.EventControllerKey()
         self.add_controller(key_controller)
@@ -421,7 +421,7 @@ class Window(Gtk.Window, BaseWidget):
 
     def __remove(self, *args) -> None:
         try:
-            app.remove_window(self.namespace)
+            window_manager.remove_window(self.namespace)
         except WindowNotFoundError:
             pass
 

--- a/ignis/window_manager.py
+++ b/ignis/window_manager.py
@@ -1,0 +1,111 @@
+from gi.repository import Gtk  # type: ignore
+from ignis.gobject import IgnisGObjectSingleton, IgnisProperty
+from ignis.exceptions import WindowAddedError, WindowNotFoundError
+
+
+class WindowManager(IgnisGObjectSingleton):
+    """
+    A class for managing window objects.
+
+    Example usage:
+
+    .. code-block:: python
+
+        from ignis.window_manager import WindowManager
+
+        window_manager = WindowManager.get_default()
+
+        # Open, close, or toggle a window
+        window_manager.open_window("window-name")
+        window_manager.close_window("window-name")
+        window_manager.toggle_window("window-name")
+
+        # Get an instance of a window
+        some_window = window_manager.get_window("window-name")
+    """
+
+    def __init__(self):
+        self._windows: dict[str, Gtk.Window] = {}
+        super().__init__()
+
+    @IgnisProperty
+    def windows(self) -> list[Gtk.Window]:
+        """
+        A list of added windows.
+        """
+        return list(self._windows.values())
+
+    def get_window(self, window_name: str) -> Gtk.Window:
+        """
+        Get a window by name.
+
+        Args:
+            window_name: The window's namespace.
+
+        Returns:
+            The window object.
+
+        Raises:
+            WindowNotFoundError: If a window with the given namespace does not exist.
+        """
+        window = self._windows.get(window_name, None)
+        if window:
+            return window
+        else:
+            raise WindowNotFoundError(window_name)
+
+    def add_window(self, window_name: str, window: Gtk.Window) -> None:
+        """
+        Add a window.
+        You typically shouldn't use this method, as windows are added to the app automatically.
+
+        Args:
+            window_name: The window's namespace.
+            window: The window instance.
+
+        Raises:
+            WindowAddedError: If a window with the given namespace already exists.
+        """
+        if window_name in self._windows:
+            raise WindowAddedError(window_name)
+
+        self._windows[window_name] = window
+
+    def open_window(self, window_name: str) -> None:
+        """
+        Open (show) a window by its name.
+
+        Args:
+            window_name: The window's namespace.
+        Raises:
+            WindowNotFoundError: If a window with the given namespace does not exist.
+        """
+        window = self.get_window(window_name)
+        window.set_visible(True)
+
+    def remove_window(self, window_name: str) -> None:
+        """
+        Remove a window by its name.
+        The window will be removed from the application.
+
+        Args:
+            window_name: The window's namespace.
+
+        Raises:
+            WindowNotFoundError: If a window with the given namespace does not exist.
+        """
+        window = self._windows.pop(window_name, None)
+        if not window:
+            raise WindowNotFoundError(window_name)
+
+    def toggle_window(self, window_name: str) -> None:
+        """
+        Toggle (change visibility to opposite state) a window by its name.
+
+        Args:
+            window_name: The window's namespace.
+        Raises:
+            WindowNotFoundError: If a window with the given namespace does not exist.
+        """
+        window = self.get_window(window_name)
+        window.set_visible(not window.get_visible())

--- a/ignis/window_manager.py
+++ b/ignis/window_manager.py
@@ -98,6 +98,19 @@ class WindowManager(IgnisGObjectSingleton):
         if not window:
             raise WindowNotFoundError(window_name)
 
+    def close_window(self, window_name: str) -> None:
+        """
+        Close (hide) a window by its name.
+
+        Args:
+            window_name: The window's namespace.
+
+        Raises:
+            WindowNotFoundError: If a window with the given namespace does not exist.
+        """
+        window = self.get_window(window_name)
+        window.set_visible(False)
+
     def toggle_window(self, window_name: str) -> None:
         """
         Toggle (change visibility to opposite state) a window by its name.

--- a/ignis/window_manager.py
+++ b/ignis/window_manager.py
@@ -71,18 +71,6 @@ class WindowManager(IgnisGObjectSingleton):
 
         self._windows[window_name] = window
 
-    def open_window(self, window_name: str) -> None:
-        """
-        Open (show) a window by its name.
-
-        Args:
-            window_name: The window's namespace.
-        Raises:
-            WindowNotFoundError: If a window with the given namespace does not exist.
-        """
-        window = self.get_window(window_name)
-        window.set_visible(True)
-
     def remove_window(self, window_name: str) -> None:
         """
         Remove a window by its name.
@@ -97,6 +85,18 @@ class WindowManager(IgnisGObjectSingleton):
         window = self._windows.pop(window_name, None)
         if not window:
             raise WindowNotFoundError(window_name)
+
+    def open_window(self, window_name: str) -> None:
+        """
+        Open (show) a window by its name.
+
+        Args:
+            window_name: The window's namespace.
+        Raises:
+            WindowNotFoundError: If a window with the given namespace does not exist.
+        """
+        window = self.get_window(window_name)
+        window.set_visible(True)
 
     def close_window(self, window_name: str) -> None:
         """

--- a/ignis/window_manager.py
+++ b/ignis/window_manager.py
@@ -57,7 +57,7 @@ class WindowManager(IgnisGObjectSingleton):
     def add_window(self, window_name: str, window: Gtk.Window) -> None:
         """
         Add a window.
-        You typically shouldn't use this method, as windows are added to the app automatically.
+        You typically shouldn't use this method, as windows are added automatically.
 
         Args:
             window_name: The window's namespace.
@@ -74,7 +74,7 @@ class WindowManager(IgnisGObjectSingleton):
     def remove_window(self, window_name: str) -> None:
         """
         Remove a window by its name.
-        The window will be removed from the application.
+        This will **not** destroy the window.
 
         Args:
             window_name: The window's namespace.
@@ -92,6 +92,7 @@ class WindowManager(IgnisGObjectSingleton):
 
         Args:
             window_name: The window's namespace.
+
         Raises:
             WindowNotFoundError: If a window with the given namespace does not exist.
         """
@@ -117,6 +118,7 @@ class WindowManager(IgnisGObjectSingleton):
 
         Args:
             window_name: The window's namespace.
+
         Raises:
             WindowNotFoundError: If a window with the given namespace does not exist.
         """


### PR DESCRIPTION
This PR moves window management from `IgnisApp` to the new `WindowManager` class.

### Motivation

1. offload responsibilities from ``IgnisApp``
2. `IgnisApp.get_default()` currently guaranteed returns the instance, which causes problems implementing #137 because ``get_default()`` actually shouldn't initialize an instance. So `WindowManager` comes as the replacement.

### Breaking Changes

The following methods and properties are deprecated, consider using the new ones:
- ``IgnisApp.windows`` -> ``WindowManager.windows``
- ``IgnisApp.get_window()`` -> ``WindowManager.get_window()``
- ``IgnisApp.add_window()`` -> ``WindowManager.add_window()``
- ``IgnisApp.remove_window()`` -> ``WindowManager.remove_window()``
- ``IgnisApp.open_window()`` -> ``WindowManager.open_window()``
- ``IgnisApp.close_window()`` -> ``WindowManager.close_window()``
- ``IgnisApp.toggle_window()`` -> ``WindowManager.toggle_window()``

#### How to use `WindowManager`?

The same as `IgnisApp`:

```python
from ignis.window_manager import WindowManager

window_manager = WindowManager.get_default()

window_manager.open_window("window-name")
# ...etc
```
