### PR TITLE
feat!: add `IconManager`

### DIFF
--- a/docs/api/icon_manager.rst
+++ b/docs/api/icon_manager.rst
@@ -1,0 +1,7 @@
+Icon Manager
+============
+
+.. currentmodule:: ignis.icon_manager
+
+.. autoclass:: IconManager
+    :members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,6 +10,7 @@ This reference manual details functions, modules, and objects included in Ignis,
    app
    window_manager
    css_manager
+   icon_manager
    singleton
    gobject
    variable

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -19,6 +19,7 @@ from ignis.exceptions import (
 )
 from ignis.log_utils import configure_logger
 from ignis.window_manager import WindowManager
+from ignis.icon_manager import IconManager
 from ignis.css_manager import CssManager, StylePriority, CssInfoPath
 from ignis._deprecation import (
     deprecated,
@@ -181,45 +182,6 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         :meta private:
         """
         self._config_path = config_path
-
-    def add_icons(self, path: str) -> None:
-        """
-        Add custom SVG icons from a directory.
-
-        The directory must contain ``hicolor/scalable/actions`` directory, icons must be inside ``actions`` directory.
-
-        Args:
-            path: Path to the directory.
-
-        For example, place icons inside the Ignis config directory:
-
-        .. code-block:: bash
-
-            ~/.config/ignis
-            ├── config.py
-            ├── icons
-            │   └── hicolor
-            │       └── scalable
-            │           └── actions
-            │               ├── aaaa-symbolic.svg
-            │               └── some-icon.svg
-
-        .. note::
-            To apply a CSS color to an icon, its name and filename must end with ``-symbolic``.
-
-        then, add this to your ``config.py`` :
-
-        .. code-block:: python
-
-            from ignis import utils
-            from ignis.app import IgnisApp
-
-            app = IgnisApp.get_default()
-
-            app.add_icons(f"{utils.get_current_dir()}/icons")
-        """
-        icon_theme = Gtk.IconTheme.get_for_display(utils.get_gdk_display())
-        icon_theme.add_search_path(path)
 
     def do_activate(self) -> None:
         """
@@ -391,6 +353,16 @@ class IgnisApp(Gtk.Application, IgnisGObject):
     @widgets_style_priority.setter
     def widgets_style_priority(self, value: StylePriority) -> None:
         self._css_manager.widgets_style_priority = value
+
+    @deprecated(
+        "IgnisApp.add_icons() is deprecated, use IconManager.add_icons() instead."
+    )
+    def add_icons(self, path: str) -> None:
+        """
+        .. deprecated:: 0.6
+            Use :func:`ignis.icon_manager.IconManager.add_icons` instead.
+        """
+        IconManager.get_default().add_icons(path)
 
     @deprecated(
         "IgnisApp.apply_css() is deprecated, use CssManager.apply_css() instead."

--- a/ignis/icon_manager.py
+++ b/ignis/icon_manager.py
@@ -1,0 +1,103 @@
+from ignis import utils
+from ignis.gobject import IgnisGObjectSingleton, IgnisProperty, IgnisSignal
+from gi.repository import Gtk  # type: ignore
+
+
+class IconManager(IgnisGObjectSingleton):
+    """
+    A simple class to add and remove custom icons.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self._icon_theme = Gtk.IconTheme.get_for_display(utils.get_gdk_display())
+        self._added_icons: list[str] = []
+
+    @IgnisSignal
+    def icons_added(self, path: str):
+        """
+        Emitted when a custom icons path has been added.
+
+        Args:
+            path: The path to icons.
+        """
+
+    @IgnisSignal
+    def icons_removed(self, path: str):
+        """
+        Emitted when a custom icons path has been removed.
+
+        Args:
+            path: The path to icons.
+        """
+
+    @IgnisProperty
+    def added_icons(self) -> list[str]:
+        """
+        The list of icon paths added via :func:`add_icons`.
+        """
+        return self._added_icons
+
+    def add_icons(self, path: str) -> None:
+        """
+        Add custom SVG icons from a directory.
+
+        The directory must contain ``hicolor/scalable/actions`` directory, icons must be inside ``actions`` directory.
+
+        Args:
+            path: Path to the directory.
+
+        For example, place icons inside the Ignis config directory:
+
+        .. code-block:: bash
+
+            ~/.config/ignis
+            ├── config.py
+            ├── icons
+            │   └── hicolor
+            │       └── scalable
+            │           └── actions
+            │               ├── aaaa-symbolic.svg
+            │               └── some-icon.svg
+
+        .. note::
+            To apply a CSS color to an icon, its name and filename must end with ``-symbolic``.
+
+        then, add this to your ``config.py``:
+
+        .. code-block:: python
+
+            import os
+            from ignis import utils
+            from ignis.icon_manager import IconManager
+
+            icon_manager = IconManager.get_default()
+
+            icon_manager.add_icons(os.path.join(utils.get_current_dir(), "icons"))
+        """
+        self._icon_theme.add_search_path(path)
+        self._added_icons.append(path)
+
+        self.notify("added-icons")
+        self.emit("icons-added", path)
+
+    def remove_icons(self, path: str) -> None:
+        """
+        Remove added icons by their path.
+
+        Args:
+            path: The path to the directory.
+        """
+        search_path = self._icon_theme.get_search_path()
+
+        if not search_path:
+            return
+
+        search_path.remove(path)
+
+        self._icon_theme.set_search_path(search_path)
+        self._added_icons.remove(path)
+
+        self.notify("added-icons")
+        self.emit("icons-removed", path)


### PR DESCRIPTION
This PR adds a new `IconManager` class to extend and replace the existing functionality provided by `IgnisApp.add_icons()`

### Breaking changes
`IgnisApp.add_icons()` is deprecated, use `IconManager.add_icons()` instead.

Replace this:
```python
from ignis import utils
from ignis.app import IgnisApp

app = IgnisApp.get_default()
app.add_icons(f"{utils.get_current_dir()}/icons")
```

with this:
```python
from ignis import utils
from ignis.icon_manager import IconManager

icon_manager = IconManager.get_default()
icon_manager.add_icons(f"{utils.get_current_dir()}/icons")
```