### PR TITLE
chore!: move `IgnisApp.inspector()` to `utils`

### DIFF
--- a/docs/api/utils/misc.rst
+++ b/docs/api/utils/misc.rst
@@ -6,3 +6,5 @@ Misc
 .. autofunction:: ignis.utils.load_interface_xml
 
 .. autofunction:: ignis.utils.get_gdk_display
+
+.. autofunction:: ignis.utils.open_inspector

--- a/ignis/_ignis_ipc.py
+++ b/ignis/_ignis_ipc.py
@@ -67,7 +67,7 @@ class IgnisIpc(IgnisGObject):
             exec(code)
 
     def __Inspector(self, invocation) -> None:
-        self._app.inspector()
+        utils.open_inspector()
 
     def __Reload(self, invocation) -> None:
         invocation.return_value(None)

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -467,6 +467,7 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         Open GTK Inspector.
 
         .. deprecated:: 0.6
+            Use :func:`ignis.utils.open_inspector` instead.
         """
         utils.open_inspector()
 

--- a/ignis/app.py
+++ b/ignis/app.py
@@ -235,12 +235,6 @@ class IgnisApp(Gtk.Application, IgnisGObject):
         super().quit()
         logger.info("Quitting.")
 
-    def inspector(self) -> None:
-        """
-        Open GTK Inspector.
-        """
-        Gtk.Window.set_interactive_debugging(True)
-
     # =========================== DEPRECATED ZONE START ===========================
 
     @IgnisProperty
@@ -464,6 +458,17 @@ class IgnisApp(Gtk.Application, IgnisGObject):
             Use :func:`~ignis.window_manager.WindowManager.remove_window` instead.
         """
         window_manager.remove_window(window_name)
+
+    @deprecated(
+        "IgnisApp.inspector() is deprecated, use utils.open_inspector() instead."
+    )
+    def inspector(self) -> None:
+        """
+        Open GTK Inspector.
+
+        .. deprecated:: 0.6
+        """
+        utils.open_inspector()
 
     # ============================ DEPRECATED ZONE END ============================
 

--- a/ignis/utils/__init__.py
+++ b/ignis/utils/__init__.py
@@ -3,7 +3,7 @@ from .debounce import DebounceTask, debounce
 from .file_monitor import FileMonitor
 from .file import read_file, read_file_async, write_file, write_file_async
 from .icon import get_paintable, get_file_icon_name, get_app_icon_name
-from .misc import load_interface_xml, get_current_dir, get_gdk_display
+from .misc import load_interface_xml, get_current_dir, get_gdk_display, open_inspector
 from .monitor import get_monitor, get_n_monitors, get_monitors
 from .pixbuf import scale_pixbuf, crop_pixbuf
 from .poll import Poll
@@ -98,4 +98,5 @@ __all__ = [
     "thread",
     "write_file",
     "write_file_async",
+    "open_inspector",
 ]

--- a/ignis/utils/misc.py
+++ b/ignis/utils/misc.py
@@ -1,6 +1,6 @@
 import os
 import inspect
-from gi.repository import Gio, Gdk  # type: ignore
+from gi.repository import Gio, Gdk, Gtk  # type: ignore
 from ignis.exceptions import DisplayNotFoundError
 
 
@@ -67,3 +67,10 @@ def get_gdk_display() -> Gdk.Display:
         return display
     else:
         raise DisplayNotFoundError()
+
+
+def open_inspector() -> None:
+    """
+    Open GTK Inspector.
+    """
+    Gtk.Window.set_interactive_debugging(True)


### PR DESCRIPTION
### Breaking changes
``IgnisApp.inspector()`` is deprecated, use ``utils.open_inspector()`` instead.