### PR TITLE
chore!: move to `ignis-gvc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,19 +20,46 @@
         "type": "github"
       }
     },
-    "gvc": {
-      "flake": false,
+    "flake-utils_2": {
+      "inputs": {
+        "systems": [
+          "ignis-gvc",
+          "systems"
+        ]
+      },
       "locked": {
-        "lastModified": 1735384240,
-        "narHash": "sha256-ikF9EzFlsRH8i4+SVUHETF4Jk1ob2JX1RLsuMdzrQOQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ignis-gvc": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1753646985,
+        "narHash": "sha256-sEVvNhb+hwnd/J/6yKPzkjKlxPvWLDcMxu2Jprvwq1U=",
         "owner": "ignis-sh",
-        "repo": "libgnome-volume-control-wheel",
-        "rev": "2d1cb33dacdae43127bb843a48b159ea7b8925d0",
+        "repo": "ignis-gvc",
+        "rev": "face8c020fa38856c7378a39cbe98c9d6d963995",
         "type": "github"
       },
       "original": {
         "owner": "ignis-sh",
-        "repo": "libgnome-volume-control-wheel",
+        "repo": "ignis-gvc",
         "type": "github"
       }
     },
@@ -55,12 +82,27 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "gvc": "gvc",
+        "ignis-gvc": "ignis-gvc",
         "nixpkgs": "nixpkgs",
-        "systems": "systems"
+        "systems": "systems_2"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",

--- a/ignis/__init__.py
+++ b/ignis/__init__.py
@@ -77,7 +77,7 @@ def get_temp_dir() -> str:
     return _temp_dir
 
 
-def _prepend_to_repo(path: str) -> None:
+def _prepend_to_repo(lib_path: str, search_path: str) -> None:
     if is_girepository_2_0:
         # Hacky? yes
         # But getting GIRepository from gi.repository and using its prepend methods results in no effect
@@ -95,8 +95,8 @@ def _prepend_to_repo(path: str) -> None:
 
         repo = GIRepository.Repository
 
-    repo.prepend_library_path(path)
-    repo.prepend_search_path(path)
+    repo.prepend_library_path(lib_path)
+    repo.prepend_search_path(search_path)
 
 
 def _init_asyncio() -> None:
@@ -124,22 +124,14 @@ def _require_versions() -> None:
     gi.require_version("Gtk4LayerShell", "1.0")
     gi.require_version("GdkPixbuf", "2.0")
 
+_GVC_LIB_DIR = "/usr/lib/ignis-gvc"
+_GVC_SEARCH_DIR = "/usr/share/ignis-gvc"
 
 def _prepend_gvc() -> None:
-    current_dir = os.path.dirname(os.path.abspath(__file__))
+    if not os.path.exists(_GVC_LIB_DIR):
+        return
 
-    if not is_editable_install:
-        _prepend_to_repo(current_dir)
-    else:
-        build_libdir = os.path.join(
-            os.path.abspath(os.path.join(current_dir, "..")),
-            "build",
-            f"cp{sys.version_info.major}{sys.version_info.minor}",
-            "subprojects",
-            "gvc",
-        )
-        _prepend_to_repo(build_libdir)
-
+    _prepend_to_repo(lib_path=_GVC_LIB_DIR, search_path=_GVC_SEARCH_DIR)
 
 def _init() -> None:
     _init_asyncio()

--- a/meson.build
+++ b/meson.build
@@ -23,17 +23,6 @@ if get_option('dependency_check')
     dependency('gtk4-layer-shell-0')
 endif
 
-# gvc
-if get_option('build_gvc')
-    subproject('gvc',
-        default_options: [
-            'package_name=' + meson.project_name(),
-            'static=false',
-            'introspection=true',
-            'alsa=false'
-        ]
-    )
-endif
 
 # Do installation
 install_subdir(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,11 +1,4 @@
 option(
-    'build_gvc',
-    type: 'boolean',
-    value: true,
-    description: 'Build gnome-volume-control (required for Audio Service).',
-)
-
-option(
     'dependency_check',
     type: 'boolean',
     value: true,

--- a/subprojects/gvc.wrap
+++ b/subprojects/gvc.wrap
@@ -1,3 +1,0 @@
-[wrap-git]
-url = https://github.com/ignis-sh/libgnome-volume-control-wheel.git
-revision = main


### PR DESCRIPTION
Building gvc as a meson subproject is pain, using `meson-python` to do it is A LOT OF PAIN. I don't fully understand how meson-python works, but trying to bundle gvc inside Ignis wheel gives headache with wrong paths. On traditional distros like Arch Linux everything is ok (though it's still required to patch gvc's `meson.build` like ignis-sh/libgnome-volume-control-wheel does). In Nix everything of course breaks and the typelib points to the wrong path of the shared library.

In general, to hell with these subprojects. It's easier to install gvc separately using ignis-sh/ignis-gvc.
Also, it gives a right for users who don't use AudioService to not build gvc.

TODO:
- [ ] Submit `ignis-gvc` package to AUR
- [ ] Test on Arch Linux
- [x] Test on NixOS