### PR TITLE
nix: remove definition of `apps`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,10 +37,6 @@
           };
           default = ignis;
         };
-        apps = rec {
-          ignis = flake-utils.lib.mkApp {drv = self.packages.${system}.ignis;};
-          default = ignis;
-        };
 
         formatter = pkgs.alejandra;
 


### PR DESCRIPTION
We have only one executable (bin) file and `nix run` works fine even without defining `apps` explicitly, so I don't see any points for keeping it.