### PR TITLE
feat: allow running custom commands from CLI

### DIFF
--- a/docs/api/command_manager.rst
+++ b/docs/api/command_manager.rst
@@ -1,7 +1,5 @@
-CommandManager
-==============
+Command Manager
+===============
 
 .. autoclass:: ignis.command_manager.CommandManager
     :members:
-
-.. autoclass:: ignis.command_manager.CommandCallback

--- a/docs/api/command_manager.rst
+++ b/docs/api/command_manager.rst
@@ -1,0 +1,7 @@
+CommandManager
+==============
+
+.. autoclass:: ignis.command_manager.CommandManager
+    :members:
+
+.. autoclass:: ignis.command_manager.CommandCallback

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -9,6 +9,7 @@ This reference manual details functions, modules, and objects included in Ignis,
    toplevel
    app
    window_manager
+   command_manager
    css_manager
    icon_manager
    config_manager

--- a/ignis/_ignis_ipc.py
+++ b/ignis/_ignis_ipc.py
@@ -2,7 +2,7 @@ from gi.repository import GLib  # type: ignore
 from ignis import utils
 from ignis.dbus import DBusService
 from ignis.gobject import IgnisGObject
-from ignis.exceptions import CommandNotFoundError, WindowNotFoundError
+from ignis.exceptions import WindowNotFoundError
 from ignis.command_manager import CommandManager
 from ignis.window_manager import WindowManager
 from typing import TYPE_CHECKING
@@ -70,9 +70,9 @@ class IgnisIpc(IgnisGObject):
     ) -> GLib.Variant:
         try:
             output = command_manager.run_command(command_name, *command_args)
-            return GLib.Variant("(bs)", (True, output or ""))
-        except CommandNotFoundError:
-            return GLib.Variant("(bs)", (False, ""))
+            return GLib.Variant("(ss)", ("", output or ""))
+        except Exception as e:
+            return GLib.Variant("(ss)", (str(e), ""))
 
     def __RunPython(self, invocation, code: str) -> None:
         invocation.return_value(None)

--- a/ignis/_ignis_ipc.py
+++ b/ignis/_ignis_ipc.py
@@ -70,7 +70,7 @@ class IgnisIpc(IgnisGObject):
     ) -> GLib.Variant:
         try:
             output = command_manager.run_command(command_name, command_args)
-            return GLib.Variant("(bs)", (True, output))
+            return GLib.Variant("(bs)", (True, output or ""))
         except CommandNotFoundError:
             return GLib.Variant("(bs)", (False, ""))
 

--- a/ignis/_ignis_ipc.py
+++ b/ignis/_ignis_ipc.py
@@ -69,7 +69,7 @@ class IgnisIpc(IgnisGObject):
         self, invocation, command_name: str, command_args: list[str]
     ) -> GLib.Variant:
         try:
-            output = command_manager.run_command(command_name, command_args)
+            output = command_manager.run_command(command_name, *command_args)
             return GLib.Variant("(bs)", (True, output or ""))
         except CommandNotFoundError:
             return GLib.Variant("(bs)", (False, ""))

--- a/ignis/_ignis_ipc.py
+++ b/ignis/_ignis_ipc.py
@@ -2,10 +2,12 @@ from gi.repository import GLib  # type: ignore
 from ignis import utils
 from ignis.dbus import DBusService
 from ignis.gobject import IgnisGObject
-from ignis.exceptions import WindowNotFoundError
+from ignis.exceptions import CommandNotFoundError, WindowNotFoundError
+from ignis.command_manager import CommandManager
 from ignis.window_manager import WindowManager
 from typing import TYPE_CHECKING
 
+command_manager = CommandManager.get_default()
 window_manager = WindowManager.get_default()
 
 if TYPE_CHECKING:
@@ -36,6 +38,10 @@ class IgnisIpc(IgnisGObject):
         self.__dbus.register_dbus_method(name="RunFile", method=self.__RunFile)
         self.__dbus.register_dbus_method(name="Reload", method=self.__Reload)
         self.__dbus.register_dbus_method(name="ListWindows", method=self.__ListWindows)
+        self.__dbus.register_dbus_method(name="RunCommand", method=self.__RunCommand)
+        self.__dbus.register_dbus_method(
+            name="ListCommands", method=self.__ListCommands
+        )
 
     def __call_window_method(self, type_: str, window_name: str) -> GLib.Variant:
         try:
@@ -55,6 +61,18 @@ class IgnisIpc(IgnisGObject):
 
     def __ListWindows(self, invocation) -> GLib.Variant:
         return GLib.Variant("(as)", (window_manager.list_window_names(),))
+
+    def __ListCommands(self, invocation) -> GLib.Variant:
+        return GLib.Variant("(as)", (command_manager.list_command_names(),))
+
+    def __RunCommand(
+        self, invocation, command_name: str, command_args: list[str]
+    ) -> GLib.Variant:
+        try:
+            output = command_manager.run_command(command_name, command_args)
+            return GLib.Variant("(bs)", (True, output))
+        except CommandNotFoundError:
+            return GLib.Variant("(bs)", (False, ""))
 
     def __RunPython(self, invocation, code: str) -> None:
         invocation.return_value(None)

--- a/ignis/cli.py
+++ b/ignis/cli.py
@@ -3,7 +3,7 @@ import click
 import subprocess
 import collections
 from ignis.client import IgnisClient
-from ignis.exceptions import WindowNotFoundError
+from ignis.exceptions import CommandNotFoundError, WindowNotFoundError
 from typing import Any
 from gi.repository import GLib  # type: ignore
 from ignis import is_editable_install
@@ -78,6 +78,9 @@ def call_client_func(name: str, *args) -> Any:
         return getattr(client, name)(*args)
     except WindowNotFoundError:
         print(f"No such window: {args[0]}")
+        exit(1)
+    except CommandNotFoundError:
+        print(f"No such command: {args[0]}")
         exit(1)
 
 
@@ -163,6 +166,21 @@ def toggle(window_name: str) -> None:
 def list_windows() -> None:
     window_list = call_client_func("list_windows")
     print("\n".join(window_list))
+
+
+@cli.command(name="list-commands", help="List names of all custom commands.")
+def list_commands() -> None:
+    command_list = call_client_func("list_commands")
+    print("\n".join(command_list))
+
+
+@cli.command(name="run-command", help="Run a custom command.")
+@click.argument("command_name")
+@click.argument("command_args", nargs=-1)
+def run_command(command_name: str, command_args: tuple[str]) -> None:
+    command_output = call_client_func("run_command", command_name, list(command_args))
+    if command_output != "":
+        print(command_output)
 
 
 @cli.command(

--- a/ignis/client.py
+++ b/ignis/client.py
@@ -1,6 +1,10 @@
 from ignis.dbus import DBusProxy
 from ignis import utils
-from ignis.exceptions import WindowNotFoundError, IgnisNotRunningError
+from ignis.exceptions import (
+    CommandNotFoundError,
+    WindowNotFoundError,
+    IgnisNotRunningError,
+)
 from typing import Any
 
 
@@ -81,6 +85,26 @@ class IgnisClient:
             list[str]: A list of all window names.
         """
         return self.__call_dbus_method("ListWindows")
+
+    def list_commands(self) -> list[str]:
+        """
+        Get a list of all command names.
+
+        Returns:
+            list[str]: A list of all command names.
+        """
+        return self.__call_dbus_method("ListCommands")
+
+    def run_command(self, command_name: str, command_args: list[str]) -> str:
+        """
+        Same as :func:`~ignis.command_manager.CommandManager.run_command`.
+        """
+        command_found, command_output = self.__call_dbus_method(
+            "RunCommand", "(sas)", command_name, command_args
+        )
+        if not command_found:
+            raise CommandNotFoundError(command_name)
+        return command_output
 
     def quit(self) -> None:
         """

--- a/ignis/client.py
+++ b/ignis/client.py
@@ -99,11 +99,13 @@ class IgnisClient:
         """
         Same as :func:`~ignis.command_manager.CommandManager.run_command`.
         """
-        command_found, command_output = self.__call_dbus_method(
+        command_error, command_output = self.__call_dbus_method(
             "RunCommand", "(sas)", command_name, command_args
         )
-        if not command_found:
+        if command_error == str(CommandNotFoundError(command_name)):
             raise CommandNotFoundError(command_name)
+        elif command_error != "":
+            raise Exception(command_error)
         return command_output
 
     def quit(self) -> None:

--- a/ignis/command_manager.py
+++ b/ignis/command_manager.py
@@ -4,18 +4,6 @@ from ignis.exceptions import CommandAddedError, CommandNotFoundError
 
 
 CommandCallback = Callable[..., str | None]
-"""
-Callback type of a custom command.
-
-Alias of ``Callable[..., str | None]``, whose arguments should be ``*args: str``.
-
-Example:
-
-.. code-block:: python
-
-    def callback(*args: str) -> str | None:
-        return " ".join(args)
-"""
 
 
 class CommandManager(IgnisGObjectSingleton):
@@ -32,8 +20,27 @@ class CommandManager(IgnisGObjectSingleton):
 
         command_manager = CommandManager.get_default()
 
-        # Add or remove a command
-        command_manager.add_command("command-name", lambda: "output message")
+        # Add a command
+        command_manager.add_command("command-name", lambda *_: "output message")
+        command_manager.add_command(
+            "command-name", lambda fmt="%H:%M", *_: set_format(fmt)
+        )
+
+        # A regular form of callbacks
+        def regular_callback(
+            arg1: str, arg_optional: str | None = None, *args: str
+        ) -> str | None:
+            if arg1 == "Hello":
+                return "world!"
+
+            if arg_optional:
+                return f"arg_optional: {arg_optional}"
+
+            return None # Nothing will be printed in CLI
+
+        command_manager.add_command("regular-command", regular_callback)
+
+        # Remove a command by name
         command_manager.remove_command("command-name")
 
         # Run a command
@@ -82,14 +89,6 @@ class CommandManager(IgnisGObjectSingleton):
 
         Raises:
             CommandAddedError: If a command with the given name already exists.
-
-        Example usage:
-
-        .. code-block:: python
-
-            command_manager = CommandManager.get_default()
-            command_manager.add_command("echo", lambda *args: " ".join(args))
-            command_manager.add_command("ping", lambda: "pong")
         """
         if command_name in self._commands:
             raise CommandAddedError(command_name)

--- a/ignis/command_manager.py
+++ b/ignis/command_manager.py
@@ -26,7 +26,14 @@ class CommandManager(IgnisGObjectSingleton):
             "command-name", lambda fmt="%H:%M", *_: set_format(fmt)
         )
 
+        # Add a command by decorator.
+        # "name" is optional, defaults to the function name.
+        @command_manager.command(name="foobar")
+        def foo_bar(*_) -> None:
+            pass
+
         # A regular form of callbacks
+        @command_manager.command(name="regular-command")
         def regular_callback(
             arg1: str, arg_optional: str | None = None, *args: str
         ) -> str | None:
@@ -37,8 +44,6 @@ class CommandManager(IgnisGObjectSingleton):
                 return f"arg_optional: {arg_optional}"
 
             return None # Nothing will be printed in CLI
-
-        command_manager.add_command("regular-command", regular_callback)
 
         # Remove a command by name
         command_manager.remove_command("command-name")
@@ -94,6 +99,20 @@ class CommandManager(IgnisGObjectSingleton):
             raise CommandAddedError(command_name)
 
         self._commands[command_name] = callback
+
+    def command(self, name: str | None = None):
+        """
+        Returns a decorator to add a command.
+
+        Args:
+            name: The command's name. If not provided, the callback's name is used.
+        """
+
+        def decorator(callback: CommandCallback):
+            self.add_command(name or callback.__name__, callback)
+            return callback
+
+        return decorator
 
     def remove_command(self, command_name: str) -> None:
         """

--- a/ignis/command_manager.py
+++ b/ignis/command_manager.py
@@ -119,6 +119,8 @@ class CommandManager(IgnisGObjectSingleton):
 
         Raises:
             CommandNotFoundError: If a command with the given name does not exist.
+            Exception: If the given arguments don't match the command's callback,
+                or if the callback raises an arbitrary Exception.
         """
         command = self.get_command(command_name)
         return command(*command_args)

--- a/ignis/command_manager.py
+++ b/ignis/command_manager.py
@@ -1,0 +1,115 @@
+from collections.abc import Callable
+from ignis.gobject import IgnisGObjectSingleton
+from ignis.exceptions import CommandAddedError, CommandNotFoundError
+
+
+class CommandManager(IgnisGObjectSingleton):
+    """
+    A class for managing custom commands.
+    A command is a function that accepts a ``list[str]`` as args
+    and optionally returns a ``str`` as output.
+
+    Example usage:
+
+    .. code-block:: python
+
+        from ignis.command_manager import CommandManager
+
+        command_manager = CommandManager.get_default()
+
+        # Add or remove a command
+        command_manager.add_command("command-name", lambda _: print("output message"))
+        command_manager.remove_command("command-name")
+
+        # Run a command
+        command_manager.run_command("command-name")
+
+        # Get the callback of a command
+        callback = command_manager.get_command("command-name")
+    """
+
+    def __init__(self):
+        self._commands: dict[str, Callable[[list[str]], str | None]] = {}
+        super().__init__()
+
+    def get_command(self, command_name: str) -> Callable[[list[str]], str | None]:
+        """
+        Get a command by name.
+
+        Args:
+            command_name: The command's name.
+
+        Returns:
+            The command callback.
+
+        Raises:
+            CommandNotFoundError: If a command with the given name does not exist.
+        """
+        command = self._commands.get(command_name, None)
+        if command:
+            return command
+        else:
+            raise CommandNotFoundError(command_name)
+
+    def add_command(
+        self, command_name: str, callback: Callable[[list[str]], str | None]
+    ) -> None:
+        """
+        Add a command.
+
+        Args:
+            command_name: The command's name.
+            callback: The command callback. It accepts an args list and optionally returns a string.
+
+        Raises:
+            CommandAddedError: If a command with the given name already exists.
+
+        Example usage:
+
+        .. code-block:: python
+
+            command_manager = CommandManager.get_default()
+            command_manager.add_command("echo", lambda args: " ".join(args))
+            command_manager.add_command("ping", lambda _: "pong")
+        """
+        if command_name in self._commands:
+            raise CommandAddedError(command_name)
+
+        self._commands[command_name] = callback
+
+    def remove_command(self, command_name: str) -> None:
+        """
+        Remove a command by its name.
+
+        Args:
+            command_name: The command's name.
+
+        Raises:
+            CommandNotFoundError: If a command with the given name does not exist.
+        """
+        command = self._commands.pop(command_name, None)
+        if not command:
+            raise CommandNotFoundError(command_name)
+
+    def run_command(self, command_name: str, command_args: list[str]) -> str:
+        """
+        Run a command by its name.
+
+        Args:
+            command_name: The command's name.
+            command_args: The args list to pass to the command.
+
+        Raises:
+            CommandNotFoundError: If a command with the given name does not exist.
+        """
+        command = self.get_command(command_name)
+        return command(command_args) or ""
+
+    def list_command_names(self) -> tuple[str, ...]:
+        """
+        List the names of commands.
+
+        Returns:
+            A tuple containing command names.
+        """
+        return tuple(self._commands.keys())

--- a/ignis/dbus/com.github.linkfrg.ignis.xml
+++ b/ignis/dbus/com.github.linkfrg.ignis.xml
@@ -24,7 +24,7 @@
         <method name="RunCommand">
             <arg direction="in" type="s" name="command-name"/>
             <arg direction="in" type="as" name="command-args"/>
-            <arg direction="out" type="b" name="command-found"/>
+            <arg direction="out" type="s" name="command-error"/>
             <arg direction="out" type="s" name="command-output"/>
         </method>
         <method name="RunPython">

--- a/ignis/dbus/com.github.linkfrg.ignis.xml
+++ b/ignis/dbus/com.github.linkfrg.ignis.xml
@@ -18,6 +18,15 @@
             <arg direction="in" type="s" name="name"/>
             <arg direction="out" type="b" name="window-found"/>
         </method>
+        <method name='ListCommands'>
+            <arg direction="out" type="as" name="commands"/>
+        </method>
+        <method name="RunCommand">
+            <arg direction="in" type="s" name="command-name"/>
+            <arg direction="in" type="as" name="command-args"/>
+            <arg direction="out" type="b" name="command-found"/>
+            <arg direction="out" type="s" name="command-output"/>
+        </method>
         <method name="RunPython">
             <arg direction="in" type="s" name="code"/>
         </method>

--- a/ignis/exceptions.py
+++ b/ignis/exceptions.py
@@ -2,6 +2,46 @@ from gi.repository import Gtk, GLib  # type: ignore
 from ignis._deprecation import deprecated
 
 
+class CommandNotFoundError(Exception):
+    """
+    Raised when a command is not found.
+
+    Args:
+        command_name: The name of the command.
+    """
+
+    def __init__(self, command_name: str, *args) -> None:
+        self._command_name = command_name
+        super().__init__(f'No such command: "{command_name}"', *args)
+
+    @property
+    def command_name(self) -> str:
+        """
+        The name of the command.
+        """
+        return self._command_name
+
+
+class CommandAddedError(Exception):
+    """
+    Raised when a command is already added.
+
+    Args:
+        command_name: The name of the command.
+    """
+
+    def __init__(self, command_name: str, *args) -> None:
+        self._command_name = command_name
+        super().__init__(f'Command already added: "{command_name}"', *args)
+
+    @property
+    def command_name(self) -> str:
+        """
+        The name of the command.
+        """
+        return self._command_name
+
+
 class WindowNotFoundError(Exception):
     """
     Raised when a window is not found.


### PR DESCRIPTION
Closes: #315.

- Added class `CommandManager` to register custom commands.
- Added _DBus_ methods `ListCommands` and `RunCommand` to query and run custom commands.
- Added subcommands `list-commands` and `run-command` to `ignis` _CLI_.

A custom command is in form `def cmd(args: list[str]) -> str | None`:
- Run `ignis run-command echo foo bar`, a callback registered as `add_command("echo", lambda args: " ".join(args))` gives the output `foo bar`.
- Run `ignis run-command ping` and a callback registered as `add_command("ping", lambda _: "pong")` prints `pong`.