### PR TITLE
docs(`NiriService`): document behavior of `active_window` if no window is focused

### DIFF
--- a/ignis/services/niri/service.py
+++ b/ignis/services/niri/service.py
@@ -86,7 +86,14 @@ class NiriService(BaseService):
     @IgnisProperty
     def active_window(self) -> NiriWindow:
         """
-        The currenly focused window.
+        The currently focused window.
+
+        .. note::
+            If there is no window is focused, it will return an "empty" :class:`NiriWindow`, where:
+
+            - all ``int``-properties are ``-1``
+            - all ``str``-properties are ``""``
+            - all ``bool``-properties are ``False``.
         """
         return self._active_window
 


### PR DESCRIPTION
Closes: #380