### PR TITLE
feat(nix): add Home Manager module

### DIFF
--- a/docs/user/nix.rst
+++ b/docs/user/nix.rst
@@ -38,6 +38,7 @@ The Home Manager module allows you to easily enable or disable optional features
 Add the module to your Home Manager configuration:
 
 .. code-block:: nix
+
     # home.nix
     {inputs, pkgs, ...}: {
         imports = [inputs.ignis.homeManagerModules.default];
@@ -46,6 +47,7 @@ Add the module to your Home Manager configuration:
 Now you can easily configure Ignis using ``programs.ignis``:
 
 .. code-block:: nix
+
     # home.nix
     {inputs, pkgs, ...}: {
       programs.ignis = {
@@ -92,6 +94,7 @@ A simple Flake example
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: nix
+
     # flake.nix
     {
       inputs = {

--- a/docs/user/nix.rst
+++ b/docs/user/nix.rst
@@ -12,6 +12,7 @@ Adding to flake
 First, add Ignis to your flake's inputs:
 
 .. code-block:: nix
+
     {
       inputs = {
         nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/docs/user/nix.rst
+++ b/docs/user/nix.rst
@@ -1,171 +1,129 @@
 Nix
-============
+===
 
-Installation
-------------
+Ignis provides a Home Manager module, which is the recommended way to install Ignis on NixOS.
 
-.. warning::
-    This will install the latest (git) version of Ignis.
-    Please refer to the `latest documentation <https://ignis-sh.github.io/ignis/latest/index.html>`_.
+.. danger::
+    You **must** refer to the `latest Ignis documentation <https://ignis-sh.github.io/ignis/latest/index.html>`_.
 
-Add Ignis to the flake's inputs:
+Adding to flake
+---------------
+
+First, add Ignis to your flake's inputs:
 
 .. code-block:: nix
-
     {
       inputs = {
-        nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+        nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
         home-manager = {
           url = "github:nix-community/home-manager";
           inputs.nixpkgs.follows = "nixpkgs";
         };
+
+        # Add Ignis here
         ignis = {
           url = "github:ignis-sh/ignis";
-          # ! Important to override
-          # Nix will not allow overriding dependencies if the input
-          # doesn't follow your system pkgs
-          inputs.nixpkgs.follows = "nixpkgs";
+          inputs.nixpkgs.follows = "nixpkgs";  # you want this
         };
       };
     }
 
-Then, add the following to ``nixpkgs.overlays``:
+Home Manager
+------------
+
+The Home Manager module allows you to easily enable or disable optional features, symlink your Ignis config directory, and much more.
+
+Add the module to your Home Manager configuration:
 
 .. code-block:: nix
+    # home.nix
+    {inputs, pkgs, ...}: {
+        imports = [inputs.ignis.homeManagerModules.default];
+    }
 
-    ignis.overlays.default
-
-
-and the following to ``environment.systemPackages`` or ``home.packages``:
+Now you can easily configure Ignis using ``programs.ignis``:
 
 .. code-block:: nix
+    # home.nix
+    {inputs, pkgs, ...}: {
+      programs.ignis = {
+        enable = true;
 
-    pkgs.ignis
+        # Make your editor's LSP work
+        addToPythonEnv = true;
 
-Extra Dependencies
-------------------
+        # Symlink config dir from your flake to ~/.config/ignis
+        configDir = ./ignis;
 
-To add extra dependencies, use the ``<pkg>.override`` function and pass the ``extraPackages`` argument to it.
+        # Enable dependencies required by some services.
+        # NOTE: This won't affect your NixOS system configuration.
+        # For example, to use NetworkService, you must enable NetworkManager
+        # in your NixOS configuration using:
+        #   networking.networkmanager.enable = true;
+        services = {
+          bluetooth.enable = true;
+          recorder.enable = true;
+          audio.enable = true;
+          network.enable = true;
+        };
 
-.. tab-set::
+        # Enable Sass support
+        sass = {
+          enable = true;
+          useDartSass = true;
+        };
 
-    .. tab-item:: configuration.nix
-
-        .. code-block:: nix
-
-            { config, pkgs, lib, ... }: {
-              environment.systemPackages = [
-                (pkgs.ignis.override {
-                  extraPackages = [
-                    # Add extra dependencies here
-                    # For example:
-                    pkgs.python313Packages.psutil
-                    pkgs.python313Packages.jinja2
-                    pkgs.python313Packages.pillow
-                    pkgs.python313Packages.materialyoucolor
-                  ];
-                })
-              ];
-            }
-
-    .. tab-item:: home.nix
-
-        .. code-block:: nix
-
-            { config, pkgs, lib, ... }: {
-              home.packages = [
-                (pkgs.ignis.override {
-                  extraPackages = [
-                    # Add extra dependencies here
-                    # For example:
-                    pkgs.python313Packages.psutil
-                    pkgs.python313Packages.jinja2
-                    pkgs.python313Packages.pillow
-                    pkgs.python313Packages.materialyoucolor
-                  ];
-                })
-              ];
-            }
+        # Extra packages available at runtime
+        # These can be regular packages or Python packages
+        extraPackages = with pkgs; [
+          hello
+          python313Packages.jinja2
+          python313Packages.materialyoucolor
+          python313Packages.pillow
+        ];
+      };
+    }
 
 
-Tips and Tricks
----------------
 
-Adding Ignis to System Python
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+A simple Flake example
+^^^^^^^^^^^^^^^^^^^^^^
 
-You can make Ignis accessible to the system Python interpreter.
-This is especially useful if the LSP server of your text editor is not able to find Ignis.
+.. code-block:: nix
+    # flake.nix
+    {
+      inputs = {
+        nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
+        home-manager = {
+          url = "github:nix-community/home-manager";
+          inputs.nixpkgs.follows = "nixpkgs";
+        };
 
-.. tab-set::
+        ignis = {
+          url = "github:ignis-sh/ignis";
+          inputs.nixpkgs.follows = "nixpkgs";
+        };
+      };
 
-    .. tab-item:: home.nix
-
-        .. code-block:: nix
-
-          { config, pkgs, ... }: {
-            home.packages = with pkgs; [
-              (python3.withPackages(ps: with ps; [
-                (pkgs.ignis.override {
-                  extraPackages = [
-                    # Add extra packages if needed
-                  ];
-                })
-              ]))
+      outputs = {
+        self,
+        nixpkgs,
+        home-manager,
+        ...
+      } @ inputs: let
+        system = "x86_64-linux";
+      in {
+        homeConfigurations = {
+          "user@hostname" = home-manager.lib.homeManagerConfiguration {
+            pkgs = nixpkgs.legacyPackages.${system};
+            # Make "inputs" accessible in home.nix
+            extraSpecialArgs = {inherit inputs;};
+            modules = [
+              ./path/to/home.nix
             ];
-          }
-
-
-.. danger::
-    You must choose only one of the described methods.
-    Do not add Ignis to the system Python if you have already added it as a package.
-
-    Otherwise, Ignis may not be able to find extra dependencies.
-
-The basic Flake example
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. tab-set::
-
-    .. tab-item:: flake.nix
-
-      .. code-block:: nix
-
-          {
-            inputs = {
-              nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-              home-manager = {
-                url = "github:nix-community/home-manager";
-                inputs.nixpkgs.follows = "nixpkgs";
-              };
-              ignis = {
-                url = "github:ignis-sh/ignis";
-                inputs.nixpkgs.follows = "nixpkgs";
-              };
-            };
-
-            outputs = { self, nixpkgs, home-manager, ignis, ... }@inputs: let
-              system = "x86_64-linux";
-              lib = nixpkgs.lib;
-            in {
-              nixosConfigurations = {
-                dummy-hostname = lib.nixosSystem {
-                  specialArgs = { inherit system inputs; };
-
-                  modules = [
-                    ./path/to/configuration.nix
-
-                    home-manager.nixosModules.home-manager {
-                      home-manager = {
-                        extraSpecialArgs = { inherit system inputs; };
-                        useGlobalPkgs = true;
-                        useUserPackages = true;
-                        users.yourUserName = import ./path/to/home.nix;
-                      };
-                    }
-                  ];
-                };
-              };
-            };
-          }
+          };
+        };
+      };
+    }

--- a/docs/user/nix.rst
+++ b/docs/user/nix.rst
@@ -1,13 +1,13 @@
 Nix
 ===
 
-Ignis provides a Home Manager module, which is the recommended way to install Ignis on NixOS.
+Ignis provides a Home Manager module, which is the recommended way to install it on NixOS.
 
 .. danger::
     You **must** refer to the `latest Ignis documentation <https://ignis-sh.github.io/ignis/latest/index.html>`_.
 
-Adding to flake
----------------
+Adding Ignis to a flake
+-----------------------
 
 First, add Ignis to your flake's inputs:
 
@@ -25,7 +25,7 @@ First, add Ignis to your flake's inputs:
         # Add Ignis here
         ignis = {
           url = "github:ignis-sh/ignis";
-          inputs.nixpkgs.follows = "nixpkgs";  # you want this
+          inputs.nixpkgs.follows = "nixpkgs";  # recommended
         };
       };
     }
@@ -33,7 +33,7 @@ First, add Ignis to your flake's inputs:
 Home Manager
 ------------
 
-The Home Manager module allows you to easily enable or disable optional features, symlink your Ignis config directory, and much more.
+The Home Manager module allows you to easily enable or disable optional features, manage the Ignis config directory, and much more.
 
 Add the module to your Home Manager configuration:
 
@@ -41,7 +41,7 @@ Add the module to your Home Manager configuration:
 
     # home.nix
     {inputs, pkgs, ...}: {
-        imports = [inputs.ignis.homeManagerModules.default];
+      imports = [inputs.ignis.homeManagerModules.default];
     }
 
 Now you can easily configure Ignis using ``programs.ignis``:
@@ -53,16 +53,18 @@ Now you can easily configure Ignis using ``programs.ignis``:
       programs.ignis = {
         enable = true;
 
-        # Make your editor's LSP work
+        # Add Ignis to the Python environment (useful for LSP support)
         addToPythonEnv = true;
 
-        # Symlink config dir from your flake to ~/.config/ignis
+        # Put a config directory from your flake into ~/.config/ignis
+        # NOTE: Home Manager will copy this directory to /nix/store
+        # and create a symbolic link to the copy.
         configDir = ./ignis;
 
-        # Enable dependencies required by some services.
+        # Enable dependencies required by certain services.
         # NOTE: This won't affect your NixOS system configuration.
-        # For example, to use NetworkService, you must enable NetworkManager
-        # in your NixOS configuration using:
+        # For example, to use NetworkService, you must also enable
+        # NetworkManager in your NixOS configuration:
         #   networking.networkmanager.enable = true;
         services = {
           bluetooth.enable = true;
@@ -88,9 +90,7 @@ Now you can easily configure Ignis using ``programs.ignis``:
       };
     }
 
-
-
-A simple Flake example
+A simple flake example
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: nix

--- a/docs/user/nix.rst
+++ b/docs/user/nix.rst
@@ -90,6 +90,8 @@ Now you can easily configure Ignis using ``programs.ignis``:
       };
     }
 
+A list of all available options can be found `here <https://github.com/ignis-sh/ignis/blob/main/nix/hm-module-doc.md>`_
+
 A simple flake example
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,6 @@
     packages = forAllSystems (system: {
       ignis = nixpkgs.legacyPackages.${system}.callPackage ./nix {
         inherit version;
-        ignis-gvc = ignis-gvc.packages.${system}.ignis-gvc;
       };
       default = self.packages.${system}.ignis;
     });
@@ -33,10 +32,15 @@
     devShells = forAllSystems (system:
       import ./nix/devshell.nix {
         inherit self;
-        ignis-gvc = ignis-gvc.packages.${system}.ignis-gvc;
         pkgs = nixpkgs.legacyPackages.${system};
+        ignis-gvc = ignis-gvc.packages.${system}.ignis-gvc;
       });
 
     overlays.default = final: prev: {inherit (self.packages.${prev.system}) ignis;};
+
+    homeManagerModules = {
+      ignis = import ./nix/hm-module.nix {inherit self ignis-gvc;};
+      default = self.homeManagerModules.ignis;
+    };
   };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,13 +6,7 @@
   gtk4-layer-shell,
   gobject-introspection,
   librsvg,
-  dart-sass,
-  pipewire,
-  networkmanager,
-  gnome-bluetooth,
   python313Packages,
-  gpu-screen-recorder,
-  ignis-gvc,
   extraPackages ? [],
   version ? "git",
 }:
@@ -31,15 +25,9 @@ python313Packages.buildPythonPackage {
     ++ [
       glib
       gtk4
-      ignis-gvc
       gtk4-layer-shell
       gobject-introspection
-      dart-sass
-      gpu-screen-recorder
       librsvg
-      pipewire
-      networkmanager
-      gnome-bluetooth
 
       python313Packages.pygobject3
       python313Packages.pycairo
@@ -54,7 +42,6 @@ python313Packages.buildPythonPackage {
     makeWrapperArgs+=(
       "''${gappsWrapperArgs[@]}"
       --set LD_LIBRARY_PATH "$out/lib:${gtk4-layer-shell}/lib:$LD_LIBRARY_PATH"
-      --set GI_TYPELIB_PATH "$out/lib:${ignis-gvc}/lib/ignis-gvc:$GI_TYPELIB_PATH"
     )
   '';
 

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -2,22 +2,32 @@
   self,
   pkgs,
   ignis-gvc,
-}: {
+}: let
+  pythonDeps = with pkgs; [
+    python3Packages.venvShellHook
+
+    (python3.withPackages (
+      ps:
+        with ps; [
+          python
+          ruff
+        ]
+    ))
+  ];
+
+  extraDeps = with pkgs; [
+    gnome-bluetooth
+    gpu-screen-recorder
+    ignis-gvc
+    networkmanager
+    dart-sass
+  ];
+in {
   default = pkgs.mkShell {
     venvDir = "./venv";
     inputsFrom = [self.packages.${pkgs.system}.ignis];
 
-    packages = with pkgs; [
-      python3Packages.venvShellHook
-
-      (python3.withPackages (
-        ps:
-          with ps; [
-            python
-            ruff
-          ]
-      ))
-    ];
+    packages = pythonDeps ++ extraDeps;
 
     postVenvCreation = ''
       pip install -r dev.txt

--- a/nix/hm-module-doc.md
+++ b/nix/hm-module-doc.md
@@ -1,0 +1,131 @@
+# NixOS Module Options
+
+
+## [`options.programs.ignis.enable`](#L15)
+
+Enable the Ignis widget framework
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+**Example:** `true`
+
+## [`options.programs.ignis.package`](#L17)
+
+The Ignis package to use
+
+**Type:** `lib.types.package`
+
+**Default:** `self.packages.${pkgs.stdenv.hostPlatform.system}.default`
+
+## [`options.programs.ignis.addToPythonEnv`](#L24)
+
+
+Wrap the package with python3.withPackages to include it in the global Python environment
+
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+**Example:** `true`
+
+## [`options.programs.ignis.configDir`](#L28)
+
+The config directory to use
+
+**Type:** `with lib.types; nullOr path`
+
+**Default:** `null`
+
+**Example:** `./ignis`
+
+## [`options.programs.ignis.services.audio.enable`](#L37)
+
+Enable Audio service
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+**Example:** `true`
+
+## [`options.programs.ignis.services.network.enable`](#L40)
+
+Enable Network service
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+**Example:** `true`
+
+## [`options.programs.ignis.services.recorder.enable`](#L43)
+
+Enable Recorder service
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+**Example:** `true`
+
+## [`options.programs.ignis.services.bluetooth.enable`](#L46)
+
+Enable Bluetooth service
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+**Example:** `true`
+
+## [`options.programs.ignis.sass.enable`](#L51)
+
+Enable Sass compilation support
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+**Example:** `true`
+
+## [`options.programs.ignis.sass.useDartSass`](#L52)
+
+Use dart-sass for Sass compilation (you probably want this)
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+**Example:** `true`
+
+## [`options.programs.ignis.sass.useGrassSass`](#L53)
+
+
+Use grass-sass for Sass compilation.
+NOTE: You can set both useDartSass and useGrassSass to true. In this case, both compilers will be available.
+
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+**Example:** `true`
+
+## [`options.programs.ignis.extraPackages`](#L59)
+
+
+Extra packages to add to the PATH.
+This is useful for adding additional Python packages that are needed by your config.
+
+
+**Type:** `with lib.types; listOf package`
+
+**Default:** `[]`
+
+**Example:** `[pkgs.python313Packages.jinja2]`
+
+---
+*Generated with [nix-options-doc](https://github.com/Thunderbottom/nix-options-doc)*

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,110 @@
+{
+  self,
+  ignis-gvc,
+}: {
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  cfg = config.programs.ignis;
+
+  ignisGvcPackage = ignis-gvc.packages.${pkgs.stdenv.hostPlatform.system}.ignis-gvc;
+in {
+  options.programs.ignis = {
+    enable = lib.mkEnableOption "Enable the Ignis widget framework";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      defaultText = lib.literalExpression "inputs.ignis.packages.${pkgs.stdenv.hostPlatform.system}.default";
+      description = "The Ignis package to use";
+    };
+
+    addToPythonEnv = lib.mkEnableOption ''
+      Wrap the package with python3.withPackages to include it in the global Python environment
+    '';
+
+    configDir = lib.mkOption {
+      type = with lib.types; nullOr path;
+      default = null;
+      example = lib.literalExpression "./ignis";
+      description = "The config directory to use";
+    };
+
+    services = {
+      audio = {
+        enable = lib.mkEnableOption "Enable Audio service";
+      };
+      network = {
+        enable = lib.mkEnableOption "Enable Network service";
+      };
+      recorder = {
+        enable = lib.mkEnableOption "Enable Recorder service";
+      };
+      bluetooth = {
+        enable = lib.mkEnableOption "Enable Bluetooth service";
+      };
+    };
+
+    sass = {
+      enable = lib.mkEnableOption "Enable Sass compilation support";
+      useDartSass = lib.mkEnableOption "Use dart-sass for Sass compilation (you probably want this)";
+      useGrassSass = lib.mkEnableOption ''
+        Use grass-sass for Sass compilation.
+        NOTE: You can set both useDartSass and useGrassSass to true. In this case, both compilers will be available.
+      '';
+    };
+
+    extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
+      default = [];
+      example = [pkgs.python313Packages.jinja2];
+      description = ''
+        Extra packages to add to the PATH.
+        This is useful for adding additional Python packages that are needed by your config.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      (lib.mkIf (cfg.configDir != null) {
+        xdg.configFile."ignis".source = cfg.configDir;
+      })
+      (let
+        pkg = (cfg.package.overrideAttrs
+          (
+            final: prev: {
+              preFixup =
+                prev.preFixup
+                + lib.optionalString cfg.services.audio.enable ''
+                  makeWrapperArgs+=(
+                    --set GI_TYPELIB_PATH "$out/lib:${ignisGvcPackage}/lib/ignis-gvc:$GI_TYPELIB_PATH"
+                  )
+                '';
+            }
+          )).override {
+          extraPackages =
+            cfg.extraPackages
+            ++ lib.optionals cfg.services.bluetooth.enable [pkgs.gnome-bluetooth]
+            ++ lib.optionals cfg.services.recorder.enable [pkgs.gpu-screen-recorder]
+            ++ lib.optionals cfg.services.audio.enable [ignisGvcPackage]
+            ++ lib.optionals cfg.services.network.enable [pkgs.networkmanager]
+            ++ lib.optionals cfg.sass.enable (
+              lib.optional cfg.sass.useDartSass pkgs.dart-sass
+              ++ lib.optional cfg.sass.useGrassSass pkgs.grass-sass
+            );
+        };
+      in {
+        home.packages = [
+          (
+            if cfg.addToPythonEnv
+            then (pkgs.python3.withPackages (_: [pkg]))
+            else pkg
+          )
+        ];
+      })
+    ]
+  );
+}


### PR DESCRIPTION
### Example usage
```nix
{
  programs.ignis = {
    enable = true;

    addToPythonEnv = true;
    configDir = ../ignis;

    services = {
      bluetooth.enable = true;
      recorder.enable = true;
      audio.enable = true;
      network.enable = true;
    };

    sass = {
      enable = true;
      useDartSass = true;
    };

    extraPackages = with pkgs.python313Packages; [
      jinja2
      materialyoucolor
      pillow
    ];
  };
}
```

TODO:
- [x] docs
