### PR TITLE
feat(HyprlandService): support `fullscreen` event

### DIFF
--- a/ignis/services/hyprland/service.py
+++ b/ignis/services/hyprland/service.py
@@ -249,6 +249,8 @@ class HyprlandService(BaseService):
             case "togglegroup":
                 self.__toggle_window_group(int(value_list[0]), value_list[1].split(","))
                 self.__sync_active_window()
+            case "fullscreen":
+                self.__sync_active_window()
 
     def __get_self_dict(self, obj_desc: _HyprlandObjDesc) -> dict:
         return getattr(self, f"_{obj_desc.prop_name}")


### PR DESCRIPTION
Not sure if this was done correctly but all this change does add a case for fullscreen and sync the active window.
As a side note, fullscreen does not return any address value just a single value the fullscreen state of the window.

closes: https://github.com/ignis-sh/ignis/issues/398