### PR TITLE
Add power profiles service

### DIFF
--- a/ignis/dbus/org.freedesktop.UPower.PowerProfiles.xml
+++ b/ignis/dbus/org.freedesktop.UPower.PowerProfiles.xml
@@ -1,0 +1,46 @@
+<node name="/">
+  <interface name="org.freedesktop.UPower.PowerProfiles">
+    <method name="HoldProfile">
+      <arg type="s" name="profile" direction="in">
+      </arg>
+      <arg type="s" name="reason" direction="in">
+      </arg>
+      <arg type="s" name="application_id" direction="in">
+      </arg>
+      <arg type="u" name="cookie" direction="out">
+      </arg>
+    </method>
+    <method name="ReleaseProfile">
+      <arg type="u" name="cookie" direction="in">
+      </arg>
+    </method>
+    <method name="SetActionEnabled">
+      <arg type="s" name="action" direction="in">
+      </arg>
+      <arg type="b" name="enabled" direction="in">
+      </arg>
+    </method>
+    <signal name="ProfileReleased">
+      <arg type="u" name="cookie">
+      </arg>
+    </signal>
+    <property type="s" name="ActiveProfile" access="readwrite">
+    </property>
+    <property type="s" name="PerformanceInhibited" access="read">
+    </property>
+    <property type="s" name="PerformanceDegraded" access="read">
+    </property>
+    <property type="aa{sv}" name="Profiles" access="read">
+    </property>
+    <property type="as" name="Actions" access="read">
+    </property>
+    <property type="aa{sv}" name="ActionsInfo" access="read">
+    </property>
+    <property type="aa{sv}" name="ActiveProfileHolds" access="read">
+    </property>
+    <property type="s" name="Version" access="read">
+    </property>
+    <property type="b" name="BatteryAware" access="readwrite">
+    </property>
+  </interface>
+</node>

--- a/ignis/services/power_profiles/__init__.py
+++ b/ignis/services/power_profiles/__init__.py
@@ -1,0 +1,5 @@
+from .service import PowerProfilesService
+
+__all__ = [
+    "PowerProfilesService",
+]

--- a/ignis/services/power_profiles/service.py
+++ b/ignis/services/power_profiles/service.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+from ignis.base_service import BaseService
+from ignis.dbus import DBusProxy
+from ignis.gobject import IgnisProperty
+from gi.repository import GLib # type: ignore
+from ignis import utils
+
+class PowerProfilesService(BaseService):
+    """
+    A service for managing power profiles through the UPower DBus interface.
+
+    Example usage:
+
+    .. code-block:: python
+
+        from ignis.services.power_profiles import PowerProfilesService 
+
+        power_profiles = PowerProfilesService.get_default()
+
+        print(power_profiles.active_profile)
+        power_profiles.active_profile = "performance"
+
+        for profile in power_profiles.profiles:
+            print(profile)
+
+        power_profiles.connect("notify::active-profile", lambda x, y: print(power_profiles.active_profile))
+    """
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._proxy = DBusProxy.new(
+            name="org.freedesktop.UPower.PowerProfiles",
+            object_path="/org/freedesktop/UPower/PowerProfiles",
+            interface_name="org.freedesktop.UPower.PowerProfiles",
+            info=utils.load_interface_xml("org.freedesktop.UPower.PowerProfiles"),
+            bus_type="system",
+        )
+
+        self._proxy.gproxy.connect("g-properties-changed", self.__on_properties_changed)
+
+        self._active_profile: str = self._proxy.ActiveProfile
+        self._profiles: list[str] = [p["Profile"] for p in self._proxy.Profiles]
+
+    @IgnisProperty
+    def active_profile( # type: ignore
+        self
+    ) -> str:
+        """
+        Current active power profile.
+
+        Should be either of:
+            - performance
+            - balanced
+            - power-saver
+        """
+        return self._active_profile
+
+    @active_profile.setter
+    def active_profile(
+        self,
+        profile: str,
+    ) -> None:
+        print(self._proxy.gproxy.HoldProfile(
+            "(sss)",
+            profile,
+            "",
+            "com.github.linkfrg.ignis"
+        ))
+
+    @IgnisProperty
+    def profiles(self) -> list[str]:
+        """
+        List of available power profiles.
+
+        Possible values are:
+            - performance
+            - balanced
+            - power-saver
+        """
+        return self._profiles
+
+    @IgnisProperty
+    def icon_name(self) -> str:
+        """
+        The current icon name representing the active power profile.
+        """
+        if self.active_profile == "performance":
+            return "power-profile-performance-symbolic"
+        if self.active_profile == "balanced":
+            return "power-profile-balanced-symbolic"
+        if self.active_profile == "power-saver":
+            return "power-profile-power-saver-symbolic"
+        return ""
+
+    def __on_properties_changed(self, _, properties: GLib.Variant, ignored):
+        prop_dict = properties.unpack()
+
+        if "ActiveProfile" in prop_dict:
+            self._active_profile = prop_dict["ActiveProfile"]
+            self.notify("active-profile")
+        if "Profiles" in prop_dict:
+            self._profiles = list(prop_dict["Profiles"].keys())
+            self.notify("profiles")
+


### PR DESCRIPTION
As the title suggests, this is a service that allows getting and setting the current power profile by interfacing through the UPower.PowerProfiles interface.

I made it a separate service for now but I'm not opposed to folding it under the existing upower service, it's up to you guys.