### PR TITLE
feat: add `Corner` widget

### DIFF
--- a/docs/api/widgets/Corner.rst
+++ b/docs/api/widgets/Corner.rst
@@ -1,0 +1,5 @@
+Corner
+------
+
+.. autoclass:: ignis.widgets.Corner
+    :members:

--- a/ignis/widgets/__init__.py
+++ b/ignis/widgets/__init__.py
@@ -1,40 +1,43 @@
 from typing import TypeAlias
-from .window import Window
-from .label import Label
-from .button import Button
-from .box import Box
-from .calendar import Calendar
-from .scale import Scale
-from .icon import Icon
-from .picture import Picture
-from .centerbox import CenterBox
-from .revealer import Revealer
-from .scroll import Scroll
-from .entry import Entry
-from .switch import Switch
-from .separator import Separator
-from .toggle_button import ToggleButton
-from .regular_window import RegularWindow
-from .file_chooser_button import FileChooserButton
-from .file_filter import FileFilter
-from .file_dialog import FileDialog
-from .grid import Grid
-from .popover_menu import PopoverMenu
-from .eventbox import EventBox
-from .headerbar import HeaderBar
-from .listboxrow import ListBoxRow
-from .listbox import ListBox
-from .check_button import CheckButton
-from .spin_button import SpinButton
-from .dropdown import DropDown
-from .overlay import Overlay
+
+from ignis._deprecation import deprecated_getattribute
+
 from .arrow import Arrow
 from .arrow_button import ArrowButton
+from .box import Box
+from .button import Button
+from .calendar import Calendar
+from .centerbox import CenterBox
+from .check_button import CheckButton
+from .corner import Corner
+from .dropdown import DropDown
+from .entry import Entry
+from .eventbox import EventBox
+from .file_chooser_button import FileChooserButton
+from .file_dialog import FileDialog
+from .file_filter import FileFilter
+from .grid import Grid
+from .headerbar import HeaderBar
+from .icon import Icon
+from .label import Label
+from .listbox import ListBox
+from .listboxrow import ListBoxRow
+from .overlay import Overlay
+from .picture import Picture
+from .popover_menu import PopoverMenu
+from .regular_window import RegularWindow
+from .revealer import Revealer
 from .revealer_window import RevealerWindow
+from .scale import Scale
+from .scroll import Scroll
+from .separator import Separator
+from .spin_button import SpinButton
 from .stack import Stack
-from .stack_switcher import StackSwitcher
 from .stack_page import StackPage
-from ignis._deprecation import deprecated_getattribute
+from .stack_switcher import StackSwitcher
+from .switch import Switch
+from .toggle_button import ToggleButton
+from .window import Window
 
 
 @deprecated_getattribute(
@@ -49,6 +52,7 @@ class Widget:
     Scale: TypeAlias = Scale
     Icon: TypeAlias = Icon
     CenterBox: TypeAlias = CenterBox
+    Corner: TypeAlias = Corner
     Revealer: TypeAlias = Revealer
     Scroll: TypeAlias = Scroll
     Entry: TypeAlias = Entry
@@ -86,6 +90,7 @@ __all__ = [
     "Calendar",
     "CenterBox",
     "CheckButton",
+    "Corner",
     "DropDown",
     "Entry",
     "EventBox",

--- a/ignis/widgets/__init__.py
+++ b/ignis/widgets/__init__.py
@@ -1,43 +1,41 @@
 from typing import TypeAlias
-
-from ignis._deprecation import deprecated_getattribute
-
+from .window import Window
+from .label import Label
+from .button import Button
+from .box import Box
+from .calendar import Calendar
+from .scale import Scale
+from .icon import Icon
+from .picture import Picture
+from .centerbox import CenterBox
+from .revealer import Revealer
+from .scroll import Scroll
+from .entry import Entry
+from .switch import Switch
+from .separator import Separator
+from .toggle_button import ToggleButton
+from .regular_window import RegularWindow
+from .file_chooser_button import FileChooserButton
+from .file_filter import FileFilter
+from .file_dialog import FileDialog
+from .grid import Grid
+from .popover_menu import PopoverMenu
+from .eventbox import EventBox
+from .headerbar import HeaderBar
+from .listboxrow import ListBoxRow
+from .listbox import ListBox
+from .check_button import CheckButton
+from .spin_button import SpinButton
+from .dropdown import DropDown
+from .overlay import Overlay
 from .arrow import Arrow
 from .arrow_button import ArrowButton
-from .box import Box
-from .button import Button
-from .calendar import Calendar
-from .centerbox import CenterBox
-from .check_button import CheckButton
-from .corner import Corner
-from .dropdown import DropDown
-from .entry import Entry
-from .eventbox import EventBox
-from .file_chooser_button import FileChooserButton
-from .file_dialog import FileDialog
-from .file_filter import FileFilter
-from .grid import Grid
-from .headerbar import HeaderBar
-from .icon import Icon
-from .label import Label
-from .listbox import ListBox
-from .listboxrow import ListBoxRow
-from .overlay import Overlay
-from .picture import Picture
-from .popover_menu import PopoverMenu
-from .regular_window import RegularWindow
-from .revealer import Revealer
 from .revealer_window import RevealerWindow
-from .scale import Scale
-from .scroll import Scroll
-from .separator import Separator
-from .spin_button import SpinButton
 from .stack import Stack
-from .stack_page import StackPage
 from .stack_switcher import StackSwitcher
-from .switch import Switch
-from .toggle_button import ToggleButton
-from .window import Window
+from .stack_page import StackPage
+from ignis._deprecation import deprecated_getattribute
+from .corner import Corner
 
 
 @deprecated_getattribute(
@@ -52,7 +50,6 @@ class Widget:
     Scale: TypeAlias = Scale
     Icon: TypeAlias = Icon
     CenterBox: TypeAlias = CenterBox
-    Corner: TypeAlias = Corner
     Revealer: TypeAlias = Revealer
     Scroll: TypeAlias = Scroll
     Entry: TypeAlias = Entry
@@ -80,6 +77,7 @@ class Widget:
     Stack: TypeAlias = Stack
     StackSwitcher: TypeAlias = StackSwitcher
     StackPage = StackPage
+    Corner: TypeAlias = Corner
 
 
 __all__ = [

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -6,6 +6,8 @@ from gi.repository import Gtk
 from ignis.base_widget import BaseWidget
 from ignis.gobject import IgnisProperty
 
+Orientation = Literal["top-left", "top-right", "bottom-left", "bottom-right"]
+
 
 class Corner(Gtk.DrawingArea, BaseWidget):
     """
@@ -38,9 +40,7 @@ class Corner(Gtk.DrawingArea, BaseWidget):
 
     def __init__(
         self,
-        orientation: Literal[
-            "top-left", "top-right", "bottom-left", "bottom-right"
-        ] = "top-right",
+        orientation: Orientation = "top-right",
         size: tuple[int, int] = (50, 50),
         **kwargs,
     ):
@@ -113,4 +113,3 @@ class Corner(Gtk.DrawingArea, BaseWidget):
         cr.paint()
 
         cr.restore()
-

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -1,8 +1,7 @@
-from typing import Literal
-
 import cairo
-from gi.repository import Gtk
 
+from typing import Literal
+from gi.repository import Gtk  # type: ignore
 from ignis.base_widget import BaseWidget
 from ignis.gobject import IgnisProperty
 

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -11,11 +11,11 @@ class Corner(Gtk.DrawingArea, BaseWidget):
     """
     Bases: :class:`Gtk.DrawingArea`
 
-    A corner widget that renders rounded corners for use in bars and panels.
+    A corner widget that renders rounded corners.
+    Useful in bars and panels.
 
     Args:
         **kwargs: Properties to set.
-
 
     .. code-block:: python
 
@@ -51,6 +51,8 @@ class Corner(Gtk.DrawingArea, BaseWidget):
             - top-right
             - bottom-left
             - bottom-right
+
+        Default: ``top-left``
         """
         return self._orientation
 

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -34,10 +34,7 @@ class Corner(Gtk.DrawingArea, BaseWidget):
     __gtype_name__ = "IgnisCorner"
     __gproperties__ = {**BaseWidget.gproperties}
 
-    def __init__(
-        self,
-        **kwargs,
-    ):
+    def __init__(self, **kwargs):
         Gtk.DrawingArea.__init__(self)
         self._orientation: Orientation = "top-left"
         BaseWidget.__init__(self, **kwargs)
@@ -68,13 +65,10 @@ class Corner(Gtk.DrawingArea, BaseWidget):
         cr: cairo.Context,
         width: int,
         height: int,
-        user_data=None,
+        *_,
     ) -> None:
-        color = self.get_color()
-
         cr.save()
 
-        # Draw corner shape based on orientation string
         match self._orientation:
             case "top-left":
                 cr.move_to(0, height)
@@ -100,8 +94,8 @@ class Corner(Gtk.DrawingArea, BaseWidget):
         cr.close_path()
         cr.clip()
 
-        if color:
+        if color := self.get_color():
             cr.set_source_rgba(color.red, color.green, color.blue, color.alpha)
-        cr.paint()
 
+        cr.paint()
         cr.restore()

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -20,8 +20,9 @@ class Corner(Gtk.DrawingArea, BaseWidget):
 
 
     .. code-block:: python
-
-        Corner(
+        
+        from ignis import widgets
+        widgets.Corner(
             orientation="top-left",
         )
     """

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -23,6 +23,11 @@ class Corner(Gtk.DrawingArea, BaseWidget):
 
         widgets.Corner(
             orientation="top-left",
+            # It's mandatory to explicitly set the width and the height
+            # Otherwise, the widget will be invisible
+            # Alternativly, you can set them in CSS using `min-width` and `min-height` properties
+            width_request=30,
+            height_request=30,
         )
     """
 

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -41,7 +41,6 @@ class Corner(Gtk.DrawingArea, BaseWidget):
     def __init__(
         self,
         orientation: Orientation = "top-right",
-        size: tuple[int, int] = (50, 50),
         **kwargs,
     ):
         Gtk.DrawingArea.__init__(self)
@@ -49,7 +48,6 @@ class Corner(Gtk.DrawingArea, BaseWidget):
 
         BaseWidget.__init__(self, **kwargs)
 
-        self.set_size_request(size[0], size[1])
         self.set_draw_func(self.__on_draw)
 
     @IgnisProperty

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -20,8 +20,8 @@ class Corner(Gtk.DrawingArea, BaseWidget):
 
 
     .. code-block:: python
-        
         from ignis import widgets
+
         widgets.Corner(
             orientation="top-left",
         )
@@ -35,7 +35,7 @@ class Corner(Gtk.DrawingArea, BaseWidget):
         **kwargs,
     ):
         Gtk.DrawingArea.__init__(self)
-self._orientation: Orientation = "top-left"
+        self._orientation: Orientation = "top-left"
         BaseWidget.__init__(self, **kwargs)
 
         self.set_draw_func(self.__on_draw)

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -1,19 +1,10 @@
-from enum import Enum
 from typing import Literal
 
 import cairo
 from gi.repository import Gtk
+
 from ignis.base_widget import BaseWidget
 from ignis.gobject import IgnisProperty
-
-
-class CornerOrientation(Enum):
-    """Enumeration for corner orientations."""
-
-    TOP_LEFT = 1
-    TOP_RIGHT = 2
-    BOTTOM_LEFT = 3
-    BOTTOM_RIGHT = 4
 
 
 class Corner(Gtk.DrawingArea, BaseWidget):
@@ -23,9 +14,15 @@ class Corner(Gtk.DrawingArea, BaseWidget):
     A corner widget that renders rounded corners for use in bars and panels.
 
     Args:
-        orientation: The corner orientation, either as a string or CornerOrientation enum.
+        orientation: The corner orientation as a string.
         size: Tuple of (width, height) for the corner size.
         **kwargs: Properties to set.
+
+    Orientation:
+        - top-left
+        - top-right
+        - bottom-left
+        - bottom-right
 
     .. code-block:: python
 
@@ -39,109 +36,41 @@ class Corner(Gtk.DrawingArea, BaseWidget):
     __gtype_name__ = "IgnisCorner"
     __gproperties__ = {**BaseWidget.gproperties}
 
-    @staticmethod
-    def render_shape(
-        cr: cairo.Context,
-        width: float,
-        height: float,
-        orientation: CornerOrientation = CornerOrientation.TOP_LEFT,
-    ) -> None:
-        """
-        Render the corner shape to the given Cairo context.
-
-        Args:
-            cr: The Cairo context to draw on.
-            width: Width of the drawing area.
-            height: Height of the drawing area.
-            orientation: The corner orientation to render.
-        """
-        cr.save()
-        match orientation:
-            case CornerOrientation.TOP_LEFT:
-                cr.move_to(0, height)
-                cr.line_to(0, 0)
-                cr.line_to(width, 0)
-                cr.curve_to(0, 0, 0, height, 0, height)
-            case CornerOrientation.TOP_RIGHT:
-                cr.move_to(width, height)
-                cr.line_to(width, 0)
-                cr.line_to(0, 0)
-                cr.curve_to(width, 0, width, height, width, height)
-            case CornerOrientation.BOTTOM_LEFT:
-                cr.move_to(0, 0)
-                cr.line_to(0, height)
-                cr.line_to(width, height)
-                cr.curve_to(0, height, 0, 0, 0, 0)
-            case CornerOrientation.BOTTOM_RIGHT:
-                cr.move_to(width, 0)
-                cr.line_to(width, height)
-                cr.line_to(0, height)
-                cr.curve_to(width, height, width, 0, width, 0)
-        cr.close_path()
-        cr.restore()
-
     def __init__(
         self,
-        orientation: Literal["top-left", "top-right", "bottom-left", "bottom-right"]
-        | CornerOrientation = CornerOrientation.TOP_RIGHT,
+        orientation: Literal[
+            "top-left", "top-right", "bottom-left", "bottom-right"
+        ] = "top-right",
         size: tuple[int, int] = (50, 50),
         **kwargs,
     ):
         Gtk.DrawingArea.__init__(self)
-        self._orientation = self._get_enum_member(CornerOrientation, orientation)
+        self._orientation: str = orientation
 
         BaseWidget.__init__(self, **kwargs)
 
         self.set_size_request(size[0], size[1])
-        self.set_draw_func(self._on_draw)
-
-    def _get_enum_member(self, enum_class, value):
-        """
-        Convert string values to enum members.
-
-        Args:
-            enum_class: The enum class to convert to.
-            value: The value to convert, either a string or enum member.
-
-        Returns:
-            The corresponding enum member.
-
-        Raises:
-            ValueError: If the string value doesn't match any enum member.
-            TypeError: If the value is neither string nor enum member.
-        """
-        if isinstance(value, enum_class):
-            return value
-
-        if isinstance(value, str):
-            enum_name = value.upper().replace("-", "_")
-            try:
-                return enum_class[enum_name]
-            except KeyError:
-                valid_values = [e.name.lower().replace("_", "-") for e in enum_class]
-                raise ValueError(
-                    f"Invalid value '{value}'. Expected one of: {valid_values}"
-                )
-
-        raise TypeError(
-            f"Expected string or {enum_class.__name__}, got {type(value).__name__}"
-        )
+        self.set_draw_func(self.__on_draw)
 
     @IgnisProperty
-    def orientation(self) -> CornerOrientation:
-        """The corner orientation."""
+    def orientation(self) -> str:
+        """
+        The corner orientation.
+
+        Orientation:
+            - top-left
+            - top-right
+            - bottom-left
+            - bottom-right
+        """
         return self._orientation
 
     @orientation.setter
-    def orientation(
-        self,
-        value: Literal["top-left", "top-right", "bottom-left", "bottom-right"]
-        | CornerOrientation,
-    ) -> None:
-        self._orientation = self._get_enum_member(CornerOrientation, value)
+    def orientation(self, value) -> None:
+        self._orientation = value
         self.queue_draw()
 
-    def _on_draw(
+    def __on_draw(
         self,
         drawing_area: Gtk.DrawingArea,
         cr: cairo.Context,
@@ -149,21 +78,34 @@ class Corner(Gtk.DrawingArea, BaseWidget):
         height: int,
         user_data=None,
     ) -> None:
-        """
-        Handle the draw event for the corner widget.
-
-        Args:
-            drawing_area: The drawing area widget.
-            cr: The Cairo context.
-            width: Width of the drawing area.
-            height: Height of the drawing area.
-            user_data: Additional user data (unused).
-        """
         color = self.get_color()
 
         cr.save()
 
-        self.render_shape(cr, width, height, self._orientation)
+        # Draw corner shape based on orientation string
+        match self._orientation:
+            case "top-left":
+                cr.move_to(0, height)
+                cr.line_to(0, 0)
+                cr.line_to(width, 0)
+                cr.curve_to(0, 0, 0, height, 0, height)
+            case "top-right":
+                cr.move_to(width, height)
+                cr.line_to(width, 0)
+                cr.line_to(0, 0)
+                cr.curve_to(width, 0, width, height, width, height)
+            case "bottom-left":
+                cr.move_to(0, 0)
+                cr.line_to(0, height)
+                cr.line_to(width, height)
+                cr.curve_to(0, height, 0, 0, 0, 0)
+            case "bottom-right":
+                cr.move_to(width, 0)
+                cr.line_to(width, height)
+                cr.line_to(0, height)
+                cr.curve_to(width, height, width, 0, width, 0)
+
+        cr.close_path()
         cr.clip()
 
         if color:
@@ -171,3 +113,4 @@ class Corner(Gtk.DrawingArea, BaseWidget):
         cr.paint()
 
         cr.restore()
+

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -1,0 +1,173 @@
+from enum import Enum
+from typing import Literal
+
+import cairo
+from gi.repository import Gtk
+from ignis.base_widget import BaseWidget
+from ignis.gobject import IgnisProperty
+
+
+class CornerOrientation(Enum):
+    """Enumeration for corner orientations."""
+
+    TOP_LEFT = 1
+    TOP_RIGHT = 2
+    BOTTOM_LEFT = 3
+    BOTTOM_RIGHT = 4
+
+
+class Corner(Gtk.DrawingArea, BaseWidget):
+    """
+    Bases: :class:`Gtk.DrawingArea`
+
+    A corner widget that renders rounded corners for use in bars and panels.
+
+    Args:
+        orientation: The corner orientation, either as a string or CornerOrientation enum.
+        size: Tuple of (width, height) for the corner size.
+        **kwargs: Properties to set.
+
+    .. code-block:: python
+
+        Corner(
+            orientation="top-left",
+            size=(20, 20),
+            class_name="corner-widget"
+        )
+    """
+
+    __gtype_name__ = "IgnisCorner"
+    __gproperties__ = {**BaseWidget.gproperties}
+
+    @staticmethod
+    def render_shape(
+        cr: cairo.Context,
+        width: float,
+        height: float,
+        orientation: CornerOrientation = CornerOrientation.TOP_LEFT,
+    ) -> None:
+        """
+        Render the corner shape to the given Cairo context.
+
+        Args:
+            cr: The Cairo context to draw on.
+            width: Width of the drawing area.
+            height: Height of the drawing area.
+            orientation: The corner orientation to render.
+        """
+        cr.save()
+        match orientation:
+            case CornerOrientation.TOP_LEFT:
+                cr.move_to(0, height)
+                cr.line_to(0, 0)
+                cr.line_to(width, 0)
+                cr.curve_to(0, 0, 0, height, 0, height)
+            case CornerOrientation.TOP_RIGHT:
+                cr.move_to(width, height)
+                cr.line_to(width, 0)
+                cr.line_to(0, 0)
+                cr.curve_to(width, 0, width, height, width, height)
+            case CornerOrientation.BOTTOM_LEFT:
+                cr.move_to(0, 0)
+                cr.line_to(0, height)
+                cr.line_to(width, height)
+                cr.curve_to(0, height, 0, 0, 0, 0)
+            case CornerOrientation.BOTTOM_RIGHT:
+                cr.move_to(width, 0)
+                cr.line_to(width, height)
+                cr.line_to(0, height)
+                cr.curve_to(width, height, width, 0, width, 0)
+        cr.close_path()
+        cr.restore()
+
+    def __init__(
+        self,
+        orientation: Literal["top-left", "top-right", "bottom-left", "bottom-right"]
+        | CornerOrientation = CornerOrientation.TOP_RIGHT,
+        size: tuple[int, int] = (50, 50),
+        **kwargs,
+    ):
+        Gtk.DrawingArea.__init__(self)
+        self._orientation = self._get_enum_member(CornerOrientation, orientation)
+
+        BaseWidget.__init__(self, **kwargs)
+
+        self.set_size_request(size[0], size[1])
+        self.set_draw_func(self._on_draw)
+
+    def _get_enum_member(self, enum_class, value):
+        """
+        Convert string values to enum members.
+
+        Args:
+            enum_class: The enum class to convert to.
+            value: The value to convert, either a string or enum member.
+
+        Returns:
+            The corresponding enum member.
+
+        Raises:
+            ValueError: If the string value doesn't match any enum member.
+            TypeError: If the value is neither string nor enum member.
+        """
+        if isinstance(value, enum_class):
+            return value
+
+        if isinstance(value, str):
+            enum_name = value.upper().replace("-", "_")
+            try:
+                return enum_class[enum_name]
+            except KeyError:
+                valid_values = [e.name.lower().replace("_", "-") for e in enum_class]
+                raise ValueError(
+                    f"Invalid value '{value}'. Expected one of: {valid_values}"
+                )
+
+        raise TypeError(
+            f"Expected string or {enum_class.__name__}, got {type(value).__name__}"
+        )
+
+    @IgnisProperty
+    def orientation(self) -> CornerOrientation:
+        """The corner orientation."""
+        return self._orientation
+
+    @orientation.setter
+    def orientation(
+        self,
+        value: Literal["top-left", "top-right", "bottom-left", "bottom-right"]
+        | CornerOrientation,
+    ) -> None:
+        self._orientation = self._get_enum_member(CornerOrientation, value)
+        self.queue_draw()
+
+    def _on_draw(
+        self,
+        drawing_area: Gtk.DrawingArea,
+        cr: cairo.Context,
+        width: int,
+        height: int,
+        user_data=None,
+    ) -> None:
+        """
+        Handle the draw event for the corner widget.
+
+        Args:
+            drawing_area: The drawing area widget.
+            cr: The Cairo context.
+            width: Width of the drawing area.
+            height: Height of the drawing area.
+            user_data: Additional user data (unused).
+        """
+        color = self.get_color()
+
+        cr.save()
+
+        self.render_shape(cr, width, height, self._orientation)
+        cr.clip()
+
+        if color:
+            cr.set_source_rgba(color.red, color.green, color.blue, color.alpha)
+        cr.paint()
+
+        cr.restore()

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -18,11 +18,6 @@ class Corner(Gtk.DrawingArea, BaseWidget):
     Args:
         **kwargs: Properties to set.
 
-    Orientation:
-        - top-left
-        - top-right
-        - bottom-left
-        - bottom-right
 
     .. code-block:: python
 

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -20,6 +20,7 @@ class Corner(Gtk.DrawingArea, BaseWidget):
 
 
     .. code-block:: python
+
         from ignis import widgets
 
         widgets.Corner(

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -1,5 +1,4 @@
 import cairo
-
 from typing import Literal
 from gi.repository import Gtk  # type: ignore
 from ignis.base_widget import BaseWidget
@@ -41,7 +40,7 @@ class Corner(Gtk.DrawingArea, BaseWidget):
         self.set_draw_func(self.__on_draw)
 
     @IgnisProperty
-    def orientation(self) -> str:
+    def orientation(self) -> Orientation:
         """
         The corner orientation.
 
@@ -54,7 +53,7 @@ class Corner(Gtk.DrawingArea, BaseWidget):
         return self._orientation
 
     @orientation.setter
-    def orientation(self, value) -> None:
+    def orientation(self, value: Orientation) -> None:
         self._orientation = value
         self.queue_draw()
 

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -42,7 +42,7 @@ class Corner(Gtk.DrawingArea, BaseWidget):
         **kwargs,
     ):
         Gtk.DrawingArea.__init__(self)
-
+self._orientation: Orientation = "top-left"
         BaseWidget.__init__(self, **kwargs)
 
         self.set_draw_func(self.__on_draw)

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -23,8 +23,6 @@ class Corner(Gtk.DrawingArea, BaseWidget):
 
         Corner(
             orientation="top-left",
-            size=(20, 20),
-            class_name="corner-widget"
         )
     """
 

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -16,7 +16,6 @@ class Corner(Gtk.DrawingArea, BaseWidget):
     A corner widget that renders rounded corners for use in bars and panels.
 
     Args:
-        orientation: The corner orientation as a string.
         **kwargs: Properties to set.
 
     Orientation:

--- a/ignis/widgets/corner.py
+++ b/ignis/widgets/corner.py
@@ -17,7 +17,6 @@ class Corner(Gtk.DrawingArea, BaseWidget):
 
     Args:
         orientation: The corner orientation as a string.
-        size: Tuple of (width, height) for the corner size.
         **kwargs: Properties to set.
 
     Orientation:
@@ -40,11 +39,9 @@ class Corner(Gtk.DrawingArea, BaseWidget):
 
     def __init__(
         self,
-        orientation: Orientation = "top-right",
         **kwargs,
     ):
         Gtk.DrawingArea.__init__(self)
-        self._orientation: str = orientation
 
         BaseWidget.__init__(self, **kwargs)
 


### PR DESCRIPTION
Adds Corner Widget, can be used as screencorners or as corners to a widget
Code formatted using ruff,docstrings written by claude
Preview and usecase: 
<img width="1919" height="1079" alt="5m172sm6" src="https://github.com/user-attachments/assets/933d8ecd-95e0-43d1-806b-5e95831d26a5" />
<img width="347" height="666" alt="image" src="https://github.com/user-attachments/assets/2d38d8f1-3005-44c9-bbff-e7dc3b059ea4" />


Closes: #200